### PR TITLE
CI env vars now base64 encoded

### DIFF
--- a/test/integration/run.sh
+++ b/test/integration/run.sh
@@ -18,11 +18,13 @@
 #
 # Required ENV vars:
 #  - $OCI_API_KEY (pointing to the pem file) or 
-#    $OCI_API_KEY_VAR (containing the pem file content)
+#    $OCI_API_KEY_VAR (containing the base64 encoded pem file content)
+#
 #  - $INSTANCE_KEY (pointing to the private key file) or 
-#    $INSTANCE_KEY_VAR (containing the private key file content)
+#    $INSTANCE_KEY_VAR (containing the base64 encoded private key file content)
+#
 #  - $INSTANCE_KEY_PUB (pointing to the public key file) or 
-#    $INSTANCE_KEY_PUB_VAR (containing the public key file content)
+#    $INSTANCE_KEY_PUB_VAR (containing the base64 encoded public key file content)
 
 set -o errexit
 set -o pipefail
@@ -48,7 +50,7 @@ function create_key_file() {
     if [[ -n "$1" ]]; then
         cp "$1" $3
     else
-        echo "$2" > $3
+        echo "$2" | openssl enc -base64 -d -A > $3
     fi
 }
 

--- a/test/integration/terraform/volume.tf
+++ b/test/integration/terraform/volume.tf
@@ -2,7 +2,7 @@ resource "oci_core_volume" "test_volume" {
   availability_domain = "${var.availability_domain}"
   compartment_id = "${var.compartment_ocid}"
   display_name = "${var.flexvolume_test_id}"
-  size_in_mbs = "51200"  # 50GB
+  size_in_gbs = "50"
 }
 
 output "volume_ocid" {

--- a/test/system/runner.py
+++ b/test/system/runner.py
@@ -51,10 +51,10 @@ def _check_env():
 
 def _create_key_files():
     if "OCI_API_KEY_VAR" in os.environ:
-        _run_command("echo \"$OCI_API_KEY_VAR\" > " + TMP_OCI_API_KEY, ".")
+        _run_command("echo \"$OCI_API_KEY_VAR\" | openssl enc -base64 -d -A > " + TMP_OCI_API_KEY, ".")
         _run_command("chmod 600 " + TMP_OCI_API_KEY, ".")
     if "INSTANCE_KEY_VAR" in os.environ:
-        _run_command("echo \"$INSTANCE_KEY_VAR\" > " + TMP_INSTANCE_KEY, ".")
+        _run_command("echo \"$INSTANCE_KEY_VAR\" | openssl enc -base64 -d -A > " + TMP_INSTANCE_KEY, ".")
         _run_command("chmod 600 " + TMP_INSTANCE_KEY, ".")
 
 


### PR DESCRIPTION
The _VAR environment variables use in CI by the integration and
system tests are now assumed to be base64 encoded, as wercker does
not support newlines in the env vars.