### PR TITLE
Adds wercker release steps

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -67,3 +67,16 @@ system-test:
         code: |
           cd test/system
           ./runner.py
+
+release:
+  steps:
+    - github-create-release:
+      token: $GITHUB_TOKEN
+      tag: $GITHUB_RELEASE_VERSION
+      title: Application $GITHUB_RELEASE_VERSION
+      draft: false
+
+    - github-upload-asset:
+      token: $GITHUB_TOKEN
+      file: $WERCKER_OUTPUT_DIR/oci
+      filename: oci


### PR DESCRIPTION
We need a GITHUB_TOKEN set. Waiting on admin to get one. 

This PR is based on work by @templecloud 

Releases will be done by manually executing the release pipeline and updating the RELEASE environment variable.

![screen shot 2017-10-30 at 16 30 45](https://user-images.githubusercontent.com/733944/32182814-857fda62-bd8f-11e7-9ca6-d7a3d1bf0068.png)


