### PR TITLE
Docker registry image for system tests should be deterministic

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -44,7 +44,7 @@ build:
 
 integration-test:
   box:
-    id: wcr.io/$DOCKER_REGISTRY_USERNAME/oci-flexvolume-driver-system-test:1.0.0
+    id: wcr.io/oracle/oci-flexvolume-driver-system-test:1.0.0
     registry: https://wcr.io/v2
     username: $DOCKER_REGISTRY_USERNAME
     password: $DOCKER_REGISTRY_PASSWORD
@@ -57,7 +57,7 @@ integration-test:
 
 system-test:
   box:
-    id: wcr.io/$DOCKER_REGISTRY_USERNAME/oci-flexvolume-driver-system-test:1.0.0
+    id: wcr.io/oracle/oci-flexvolume-driver-system-test:1.0.0
     registry: https://wcr.io/v2
     username: $DOCKER_REGISTRY_USERNAME
     password: $DOCKER_REGISTRY_PASSWORD


### PR DESCRIPTION
This change hardcodes the docker registry image for system tests since it should exist in a fixed location.