### PR TITLE
System test image creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,9 +17,6 @@ bin/
 *.dylib
 *.pyc
 
-# Test binary, build with `go test -c`
-*.test
-
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,7 @@
+FROM wcr.io/oracle/oci-flexvolume-driver-system-test:1.0.0
+
+COPY test/system /test/system
+
+WORKDIR /test/system
+
+CMD ["./runner.py"]

--- a/wercker.yml
+++ b/wercker.yml
@@ -49,11 +49,31 @@ system-test:
     registry: https://wcr.io/v2
     username: $DOCKER_REGISTRY_USERNAME
     password: $DOCKER_REGISTRY_PASSWORD
+
   steps:
+    - script:
+      name: set ENV vars
+      code: |
+        export VERSION=$(cat dist/VERSION.txt)
+        echo "Pushing test version ${VERSION}"
+
+    - script:
+      name: prepare
+      code: |
+        mkdir /test
+        mv ./test/system /test/system
+
+    - internal/docker-push:
+      repository: wcr.io/oracle/oci-flexvolume-driver-test
+      tag: $VERSION
+      working-dir: /test/system
+      entrypoint: ./runner.py
+      user: 65534 # nobody
+
     - script:
         name: system test
         code: |
-          cd test/system
+          cd /test/system
           ./runner.py
 
 release:


### PR DESCRIPTION
We now create a system test image as part of the build.
This image can then be used to validate a preexisting
deployed flexvolume driver inside a cluster.