### PR TITLE
Updated the system test to match the latest test image contract.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ test/system/terraform/terraform.tfstate.backup
 test/system/ansible_inventory
 test/system/replication-controller.yaml
 test/system/runner.log
+test/system/run-test-image.yaml*
 
 *.retry
 ansible/hosts

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,5 +1,7 @@
-FROM wcr.io/oracle/oci-flexvolume-driver-system-test:1.0.0
+FROM wcr.io/oracle/oci-flexvolume-driver-system-test:1.0.2
 
+COPY ansible /ansible
+COPY dist /dist
 COPY test/system /test/system
 
 WORKDIR /test/system

--- a/ansible/roles/oci-flexvolume-driver/templates/config.yaml.j2
+++ b/ansible/roles/oci-flexvolume-driver/templates/config.yaml.j2
@@ -5,3 +5,4 @@ auth:
   key: |
     {{ lookup('file', oci_key_file) | indent(width=4) }}
   fingerprint: {{ oci_fingerprint }}
+  vcn: {{ oci_vcn }}

--- a/ci-docker-images/oci-flexvolume-driver-system-test/Dockerfile
+++ b/ci-docker-images/oci-flexvolume-driver-system-test/Dockerfile
@@ -16,6 +16,7 @@ FROM ubuntu:16.04
 
 ARG TERRAFORM_VERSION=0.10.7
 ARG OCI_TERRAFORM_PROVIDER_VERSION="2.0.2"
+ARG KUBECTL_VERSION=v1.9.4
 
 # Installs the required dependencies.
 RUN apt-get update && apt-get install -y \
@@ -25,7 +26,10 @@ RUN apt-get update && apt-get install -y \
     python \
     software-properties-common \
     unzip \
-    wget
+    wget \
+    curl\
+    jq \
+    pwgen
 
 RUN apt-add-repository ppa:ansible/ansible \
     && apt-get update \
@@ -40,3 +44,8 @@ RUN mv terraform /usr/bin/
 RUN wget https://github.com/oracle/terraform-provider-oci/releases/download/${OCI_TERRAFORM_PROVIDER_VERSION}/linux.tar.gz
 RUN tar -xzvf linux.tar.gz -C /
 RUN echo "providers { oci = \"/linux_amd64/terraform-provider-oci_v${OCI_TERRAFORM_PROVIDER_VERSION}\" }" > ~/.terraformrc
+
+# Installs the kubectl client
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl
+RUN chmod +x ./kubectl
+RUN mv ./kubectl /usr/local/bin/kubectl

--- a/ci-docker-images/oci-flexvolume-driver-system-test/Makefile
+++ b/ci-docker-images/oci-flexvolume-driver-system-test/Makefile
@@ -15,7 +15,7 @@
 DOCKER_REPO ?= wcr.io
 DOCKER_USER ?= oracle
 DOCKER_IMAGE_NAME ?= oci-flexvolume-driver-system-test
-VERSION ?= 1.0.0
+VERSION ?= 1.0.3
 IMAGE ?= ${DOCKER_REPO}/${DOCKER_USER}/${DOCKER_IMAGE_NAME}
 
 .PHONY: build

--- a/pkg/oci/client/config.go
+++ b/pkg/oci/client/config.go
@@ -176,6 +176,9 @@ func validateConfig(c *Config) field.ErrorList {
 	if c.Auth.Fingerprint == "" {
 		errList = append(errList, field.Required(field.NewPath("fingerprint"), ""))
 	}
+	if c.Auth.VcnOCID == "" {
+		errList = append(errList, field.Required(field.NewPath("vcn"), ""))
+	}
 
 	return errList
 }

--- a/pkg/oci/client/config_test.go
+++ b/pkg/oci/client/config_test.go
@@ -116,6 +116,7 @@ func TestValidateConfig(t *testing.T) {
 					UserOCID:        "ocid1.user.oc1..aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 					PrivateKey:      "-----BEGIN RSA PRIVATE KEY----- (etc)",
 					Fingerprint:     "d4:1d:8c:d9:8f:00:b2:04:e9:80:09:98:ec:f8:42:7e",
+					VcnOCID:         "ocid1.user.oc1..aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 				},
 			},
 			errs: field.ErrorList{},
@@ -129,6 +130,7 @@ func TestValidateConfig(t *testing.T) {
 					UserOCID:        "ocid1.user.oc1..aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 					PrivateKey:      "-----BEGIN RSA PRIVATE KEY----- (etc)",
 					Fingerprint:     "d4:1d:8c:d9:8f:00:b2:04:e9:80:09:98:ec:f8:42:7e",
+					VcnOCID:         "ocid1.user.oc1..aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 				},
 			},
 			errs: field.ErrorList{
@@ -144,6 +146,7 @@ func TestValidateConfig(t *testing.T) {
 					UserOCID:        "ocid1.user.oc1..aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 					PrivateKey:      "-----BEGIN RSA PRIVATE KEY----- (etc)",
 					Fingerprint:     "d4:1d:8c:d9:8f:00:b2:04:e9:80:09:98:ec:f8:42:7e",
+					VcnOCID:         "ocid1.user.oc1..aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 				},
 			},
 			errs: field.ErrorList{
@@ -159,6 +162,7 @@ func TestValidateConfig(t *testing.T) {
 					UserOCID:        "ocid1.user.oc1..aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 					PrivateKey:      "-----BEGIN RSA PRIVATE KEY----- (etc)",
 					Fingerprint:     "d4:1d:8c:d9:8f:00:b2:04:e9:80:09:98:ec:f8:42:7e",
+					VcnOCID:         "ocid1.user.oc1..aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 				},
 			},
 			errs: field.ErrorList{
@@ -174,6 +178,7 @@ func TestValidateConfig(t *testing.T) {
 					UserOCID:    "ocid1.user.oc1..aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 					PrivateKey:  "-----BEGIN RSA PRIVATE KEY----- (etc)",
 					Fingerprint: "d4:1d:8c:d9:8f:00:b2:04:e9:80:09:98:ec:f8:42:7e",
+					VcnOCID:     "ocid1.user.oc1..aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 				},
 			},
 			errs: field.ErrorList{
@@ -189,6 +194,7 @@ func TestValidateConfig(t *testing.T) {
 					TenancyOCID:     "ocid1.tennancy.oc1..aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 					PrivateKey:      "-----BEGIN RSA PRIVATE KEY----- (etc)",
 					Fingerprint:     "d4:1d:8c:d9:8f:00:b2:04:e9:80:09:98:ec:f8:42:7e",
+					VcnOCID:         "ocid1.user.oc1..aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 				},
 			},
 			errs: field.ErrorList{
@@ -204,6 +210,7 @@ func TestValidateConfig(t *testing.T) {
 					TenancyOCID:     "ocid1.tennancy.oc1..aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 					UserOCID:        "ocid1.user.oc1..aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 					Fingerprint:     "d4:1d:8c:d9:8f:00:b2:04:e9:80:09:98:ec:f8:42:7e",
+					VcnOCID:         "ocid1.user.oc1..aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 				},
 			},
 			errs: field.ErrorList{
@@ -219,10 +226,27 @@ func TestValidateConfig(t *testing.T) {
 					TenancyOCID:     "ocid1.tennancy.oc1..aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 					UserOCID:        "ocid1.user.oc1..aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 					PrivateKey:      "-----BEGIN RSA PRIVATE KEY----- (etc)",
+					VcnOCID:         "ocid1.user.oc1..aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 				},
 			},
 			errs: field.ErrorList{
 				&field.Error{Type: field.ErrorTypeRequired, Field: "fingerprint", BadValue: ""},
+			},
+		}, {
+			name: "missing_vcn",
+			in: &Config{
+				Auth: AuthConfig{
+					Region:          "us-phoenix-1",
+					RegionKey:       "phx",
+					CompartmentOCID: "ocid1.compartment.oc1..aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+					TenancyOCID:     "ocid1.tennancy.oc1..aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+					UserOCID:        "ocid1.user.oc1..aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+					PrivateKey:      "-----BEGIN RSA PRIVATE KEY----- (etc)",
+					Fingerprint:     "d4:1d:8c:d9:8f:00:b2:04:e9:80:09:98:ec:f8:42:7e",
+				},
+			},
+			errs: field.ErrorList{
+				&field.Error{Type: field.ErrorTypeRequired, Field: "vcn", BadValue: ""},
 			},
 		},
 	}

--- a/test/integration/run.sh
+++ b/test/integration/run.sh
@@ -111,7 +111,7 @@ chmod 600 _tmp/oci_api_key.pem
 
 export TF_VAR_ssh_public_key="$(cat _tmp/instance_key.pub)"
 export TF_VAR_ssh_private_key="$(cat _tmp/instance_key)"
-
+export TF_VAR_vcn=$VCN
 export TF_VAR_test_id="flexvolume-driver-integration-$(date '+%Y-%m-%d-%H-%M')"
 
 # Provision OCI instance and block storage volume for test.

--- a/test/integration/terraform/config.yaml.tpl
+++ b/test/integration/terraform/config.yaml.tpl
@@ -5,3 +5,4 @@ auth:
   key: |
     ${key}
   fingerprint: 2c:29:18:b4:86:a5:d4:02:07:f4:41:6f:7d:64:02:11
+  vcn: ocid1.vcn.oc1.phx.aaaaaaaaqh26l5f3bvnjz5wmelm6vntqotm42er6wrsy4nllovdtzpemcsyq

--- a/test/integration/terraform/config.yaml.tpl
+++ b/test/integration/terraform/config.yaml.tpl
@@ -5,4 +5,4 @@ auth:
   key: |
     ${key}
   fingerprint: 2c:29:18:b4:86:a5:d4:02:07:f4:41:6f:7d:64:02:11
-  vcn: ocid1.vcn.oc1.phx.aaaaaaaaqh26l5f3bvnjz5wmelm6vntqotm42er6wrsy4nllovdtzpemcsyq
+  vcn: ${vcn}

--- a/test/integration/terraform/instance.tf
+++ b/test/integration/terraform/instance.tf
@@ -6,6 +6,10 @@ variable "ssh_private_key" {
   default = ""
 }
 
+variable "vcn" {
+  default = ""
+}
+
 variable subnet_ocid {
   default = "ocid1.subnet.oc1.phx.aaaaaaaab7gsl5sqgnxhrjwsg2ztk73c7thwnfzgtkof7h6umoby6e7yaj7q"
 }
@@ -46,6 +50,7 @@ data "template_file" "driver_config" {
   template = "${file("${path.module}/config.yaml.tpl")}"
   vars {
       key = "${ indent(4, file("${path.module}/_tmp/oci_api_key.pem")) }"
+      vcn = "${var.vcn}"
   }
 }
 

--- a/test/system/README.md
+++ b/test/system/README.md
@@ -4,6 +4,37 @@ Some scripts to test the OCI Flexvolume driver using a real Kubernetes cluster.
 
 ## Usage
 
+We first need to setup the environment. The following must be defined:
+
+* $KUBECONFIG or $KUBECONFIG\_VAR
+
+If --create-using-oci flag is set, then the following will
+need to be defined:
+
+* $OCI\_API\_KEY or $OCI\_API\_KEY\_VAR
+
+Note: If set, OCI\_API\_KEY/KUBECONFIG must contain the path to the required
+files. Alternatively, OCI\_API\_KEY\_VAR/KUBECONFIG\_VAR must contain the content
+of the required files (base64 encoded). If both are set, the former will
+take precedence.
+
+If the --enforce-cluster-locking flag is set, then the following will 
+need to be defined:
+
+* $INSTANCE\_KEY or $INSTANCE\_KEY\_VAR
+* $MASTER\_IP
+* $SLAVE0\_IP
+* $SLAVE1\_IP
+* $WERCKER\_API\_TOKEN
+
+If the --install flag is set, then the following will 
+need to be defined:
+
+* $MASTER\_IP
+* $SLAVE0\_IP
+* $SLAVE1\_IP
+* $VCN
+
 We can then run the system test as follows:
 
 ```

--- a/test/system/playbook.yaml
+++ b/test/system/playbook.yaml
@@ -8,6 +8,7 @@
       # see TMP_OCI_API_KEY in runner.py
       oci_key_file: "/tmp/oci_api_key.pem"
       oci_flexvolume_driver_mode: master
+      oci_vcn: "{{ lookup('env','VCN') }}"
       become: true
   tasks:
     - name: restart controller

--- a/test/system/replication-controller-with-volume-claim.yaml.template
+++ b/test/system/replication-controller-with-volume-claim.yaml.template
@@ -1,4 +1,16 @@
 apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nginx-pvc-{{TEST_ID}}
+spec:
+  storageClassName: "oci"
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 50Gi
+---
+apiVersion: v1
 kind: ReplicationController
 metadata:
   name: nginx-controller-{{TEST_ID}}
@@ -17,10 +29,9 @@ spec:
         ports:
         - containerPort: 80
         volumeMounts:
-        - name: {{VOLUME_NAME}}
+        - name: vol
           mountPath: /usr/share/nginx/html
       volumes:
-      - name: {{VOLUME_NAME}}
-        flexVolume:
-          driver: "oracle/oci"
-          fsType: "ext4"
+      - name: vol
+        persistentVolumeClaim:
+          claimName: nginx-pvc-{{TEST_ID}}    

--- a/test/system/run-test-image.sh
+++ b/test/system/run-test-image.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Copyright 2017 Oracle and/or its affiliates. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DIR="$( cd "$(dirname "$0")" ; pwd -P )"
+if [ "$#" -ne 1 ]; then
+    echo "Invalid args: Usage: ./run-test-image.sh <image:version>"
+    exit 1
+fi
+VERSION=$1
+DOCKER_REGISTRY_USERNAME=${DOCKER_REGISTRY_USERNAME:-oracle}
+TEST_ID=$(pwgen -A 8 1)
+
+# Create the test image pod yaml
+cat $DIR/run-test-image.yaml.template | \
+    sed "s/{{VERSION}}/$VERSION/g" | \
+    sed "s/{{DOCKER_REGISTRY_USERNAME}}/$DOCKER_REGISTRY_USERNAME/g" | \
+    sed "s/{{TEST_ID}}/$TEST_ID/g" \
+    > $DIR/run-test-image.yaml.$TEST_ID
+
+if [[ -z "${KUBECONFIG}" ]]; then
+    if [[ -z "${KUBECONFIG_VAR}" ]]; then
+        echo "KUBECONFIG or KUBECONFIG_VAR must be set"
+        exit 1
+    else
+       echo "$KUBECONFIG_VAR" | openssl enc -base64 -d -A > /tmp/kubeconfig
+       export KUBECONFIG=/tmp/kubeconfig
+   fi
+fi
+
+# Starts the test image inside the cluster and waits for it to complete.
+exitCodeCmd="kubectl get po flexvolume-driver-system-test-$TEST_ID -o json | jq '.status.containerStatuses[0].state.terminated.exitCode'"
+kubectl create -f $DIR/run-test-image.yaml.$TEST_ID
+while [ "$(eval $exitCodeCmd)" == null ]; do
+    echo -n "."
+    sleep 30
+done
+kubectl logs flexvolume-driver-system-test-$TEST_ID
+exitCode=$(eval $exitCodeCmd)
+kubectl delete -f $DIR/run-test-image.yaml.$TEST_ID
+exit $exitCode

--- a/test/system/run-test-image.yaml.template
+++ b/test/system/run-test-image.yaml.template
@@ -1,0 +1,38 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: oci-flexvolume-driver-system-test-{{TEST_ID}}
+rules:
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["*"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: oci-flexvolume-driver-system-test-{{TEST_ID}}
+subjects:
+  - kind: ServiceAccount
+    name: oci-flexvolume-driver-system-test-{{TEST_ID}}
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: oci-flexvolume-driver-system-test-{{TEST_ID}}
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: oci-flexvolume-driver-system-test-{{TEST_ID}}
+  namespace: default
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: flexvolume-driver-system-test-{{TEST_ID}}
+spec:
+  serviceAccountName: oci-flexvolume-driver-system-test-{{TEST_ID}}
+  containers:
+  - name: flexvolume-driver-system-test
+    image: wcr.io/{{DOCKER_REGISTRY_USERNAME}}/oci-flexvolume-driver-test:{{VERSION}}
+  restartPolicy: Never

--- a/wercker.yml
+++ b/wercker.yml
@@ -32,10 +32,7 @@ build:
 
 integration-test:
   box:
-    id: wcr.io/oracle/oci-flexvolume-driver-system-test:1.0.0
-    registry: https://wcr.io/v2
-    username: $DOCKER_REGISTRY_USERNAME
-    password: $DOCKER_REGISTRY_PASSWORD
+    id: wcr.io/oracle/oci-flexvolume-driver-system-test:1.0.3
   steps:
     - script:
         name: integration test
@@ -45,36 +42,49 @@ integration-test:
 
 system-test:
   box:
-    id: wcr.io/oracle/oci-flexvolume-driver-system-test:1.0.0
-    registry: https://wcr.io/v2
-    username: $DOCKER_REGISTRY_USERNAME
-    password: $DOCKER_REGISTRY_PASSWORD
-
+    id: wcr.io/oracle/oci-flexvolume-driver-system-test:1.0.3
   steps:
     - script:
       name: set ENV vars
       code: |
-        export VERSION=$(cat dist/VERSION.txt)
+        export VERSION=$(cat VERSION.txt)
         echo "Pushing test version ${VERSION}"
 
     - script:
       name: prepare
       code: |
         mkdir /test
-        mv ./test/system /test/system
+        cp -R ./ansible /ansible
+        cp -R ./dist /dist
+        cp -R ./test/system /test/system
 
     - internal/docker-push:
       repository: wcr.io/oracle/oci-flexvolume-driver-test
       tag: $VERSION
       working-dir: /test/system
       entrypoint: ./runner.py
-      user: 65534 # nobody
 
     - script:
         name: system test
         code: |
           cd /test/system
-          ./runner.py
+          ./runner.py --no-cluster-check --create-using-oci --enforce-cluster-locking --install --destructive
+
+validate-test-image:
+  box:
+    id: wcr.io/oracle/oci-flexvolume-driver-system-test:1.0.3
+  steps:
+    - script:
+      name: set ENV vars
+      code: |
+        export VERSION=$(cat VERSION.txt)
+        echo "Test image version ${VERSION}"
+
+    - script:
+        name: validate test image
+        code: |
+          cd ./test/system
+          ./run-test-image.sh $VERSION
 
 release:
   steps:


### PR DESCRIPTION
The system test has now been updated to match the latest test image contract, i.e. by default, the test image will expect the KUBECONFIG/KUBECONFIG_VAR environment variable to be set as input, and will return 0/1 on pass/failure.