### PR TITLE
Update configuration field for private key passphrase

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ auth:
     -----BEGIN RSA PRIVATE KEY-----
     <snip>
     -----END RSA PRIVATE KEY-----
+  passphrase: my secret passphrase
   fingerprint: d4:1d:8c:d9:8f:00:b2:04:e9:80:09:98:ec:f8:42:7e
   vcn: ocid1.vcn.oc1.phx.aaaaaaaaqiqmei4yen2fuyqaiqfcejpguqs6tuaf2n2iaxiwf5cfji2s636a
 ```

--- a/pkg/oci/client/config.go
+++ b/pkg/oci/client/config.go
@@ -46,7 +46,7 @@ type AuthConfig struct {
 	UserOCID             string `yaml:"user"`
 	PrivateKey           string `yaml:"key"`
 	Passphrase           string `yaml:"passphrase"`
-	PrivateKeyPassphrase string `yaml:"key_passphrase"` // DEPRECIATED
+	PrivateKeyPassphrase string `yaml:"key_passphase"` // DEPRECIATED
 	Fingerprint          string `yaml:"fingerprint"`
 	VcnOCID              string `yaml:"vcn"`
 }

--- a/pkg/oci/client/config.go
+++ b/pkg/oci/client/config.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"os"
 	"strings"
 
@@ -44,7 +45,8 @@ type AuthConfig struct {
 	CompartmentOCID      string `yaml:"compartment"`
 	UserOCID             string `yaml:"user"`
 	PrivateKey           string `yaml:"key"`
-	PrivateKeyPassphrase string `yaml:"key_passphase"`
+	Passphrase           string `yaml:"passphrase"`
+	PrivateKeyPassphrase string `yaml:"key_passphrase"` // DEPRECIATED
 	Fingerprint          string `yaml:"fingerprint"`
 	VcnOCID              string `yaml:"vcn"`
 }
@@ -116,6 +118,12 @@ func (c *Config) setDefaults() error {
 	if err != nil {
 		return fmt.Errorf("setting config region fields: %v", err)
 	}
+
+	if c.Auth.Passphrase == "" && c.Auth.PrivateKeyPassphrase != "" {
+		log.Print("config: auth.key_passphrase is DEPRECIATED and will be removed in a later release. Please set auth.passphrase instead.")
+		c.Auth.Passphrase = c.Auth.PrivateKeyPassphrase
+	}
+
 	return nil
 }
 

--- a/pkg/oci/client/oci.go
+++ b/pkg/oci/client/oci.go
@@ -91,7 +91,7 @@ func New(configPath string) (Interface, error) {
 		config.Auth.Region,
 		config.Auth.Fingerprint,
 		config.Auth.PrivateKey,
-		&config.Auth.PrivateKeyPassphrase,
+		&config.Auth.Passphrase,
 	)
 	computeClient, err := core.NewComputeClientWithConfigurationProvider(configProvider)
 	if err != nil {


### PR DESCRIPTION
Fixes #78 

The original field contains a typo and should be aggressively dropped / depreciated. 

This field is referenced in https://github.com/oracle/terraform-kubernetes-installer/blob/master/kubernetes/oci-flexvolume-driver/config.yaml#L8 which will need to be subsequently updated before depreciation. 