### PR TITLE
Update to latest OEL OCI image

### DIFF
--- a/test/integration/terraform/instance.tf
+++ b/test/integration/terraform/instance.tf
@@ -17,7 +17,7 @@ variable subnet_ocid {
 # Gets the OCID of the OS image to use
 data "oci_core_images" "os_image_ocid" {
   compartment_id = "${var.compartment_ocid}"
-  display_name   = "Oracle-Linux-7.4-2018.01.10-0"
+  display_name   = "Oracle-Linux-7.4-2018.02.21-1"
 }
 
 resource "oci_core_instance" "instance" {


### PR DESCRIPTION
Fixes failing tests due to expired image that's breaking other PR's.