### PR TITLE
Return error if no subnets defined in vcn

### DIFF
--- a/pkg/oci/client/oci.go
+++ b/pkg/oci/client/oci.go
@@ -236,7 +236,7 @@ func (c *client) findInstanceByNodeNameIsVnic(cache *cache.OCICache, nodeName st
 		return nil, err
 	}
 	if len(*subnets) == 0 {
-		return nil, fmt.Errorf("No subnets defined for VCN: %s", c.config.Auth.VcnOCID)
+		return nil, fmt.Errorf("no subnets defined for VCN: %s", c.config.Auth.VcnOCID)
 	}
 
 	var running []core.Instance

--- a/pkg/oci/client/oci.go
+++ b/pkg/oci/client/oci.go
@@ -235,6 +235,9 @@ func (c *client) findInstanceByNodeNameIsVnic(cache *cache.OCICache, nodeName st
 		log.Printf("Error getting subnets for VCN: %s", c.config.Auth.VcnOCID)
 		return nil, err
 	}
+	if len(*subnets) == 0 {
+		return nil, fmt.Errorf("No subnets defined for VCN: %s", c.config.Auth.VcnOCID)
+	}
 
 	var running []core.Instance
 	var page *string


### PR DESCRIPTION
The instance lookup logic currently silently exits when no subnets are
defined in the vcn. This error will cause this to be logged and should
help in debugging.