### PR TITLE
Fixes boilerplate check to handle 2018 copyright notices

### DIFF
--- a/hack/boilerplate/boilerplate.py
+++ b/hack/boilerplate/boilerplate.py
@@ -17,6 +17,7 @@
 from __future__ import print_function
 
 import argparse
+import datetime
 import difflib
 import glob
 import os
@@ -184,13 +185,16 @@ def get_files(extensions):
             outfiles.append(pathname)
     return outfiles
 
+def get_dates():
+    years = datetime.datetime.now().year
+    return '(%s)' % '|'.join((str(year) for year in range(2017, years+1)))
 
 def get_regexs():
     regexs = {}
     # Search for "YEAR" which exists in the boilerplate, but shouldn't in the real thing
     regexs["year"] = re.compile('YEAR')
     # dates can be 2014, 2015, 2016, or 2017; company holder names can be anything
-    regexs["date"] = re.compile('(2017)')
+    regexs["date"] = re.compile(get_dates())
     # strip // +build \n\n build constraints
     regexs["go_build_constraints"] = re.compile(r"^(// \+build.*\n)+\n", re.MULTILINE)
     # strip #!.* from shell scripts


### PR DESCRIPTION
Longer term I'd like to replace this boilerplate stuff with a custom script but this solves any issues for now with dates in copyright headers.