### PR TITLE
Prefix process ID to log messages

### DIFF
--- a/cmd/oci/main.go
+++ b/cmd/oci/main.go
@@ -44,6 +44,9 @@ func main() {
 		os.Exit(1)
 	}
 	defer f.Close()
+
+	log.SetPrefix(fmt.Sprintf("%d ", os.Getpid()))
+
 	log.SetOutput(f)
 
 	log.Printf("OCI FlexVolume Driver version: %s (%s)", version, build)


### PR DESCRIPTION
Fix: #103 

Adds a simple prefix of process ID to the log file.