### PR TITLE
Configure flexvolume driver with secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ installed on every node in your Kubernetes cluster.
 
 ### Kubernetes DaemonSet Installer
 
-The recommended way to install the driver is through the daemonset installer mechanism.
+The recommended way to install the driver is through the daemonset installer mechanism. This will create two daemonsets, one specifically for master nodes, allowing configuration via a Kubernetes Secret, and one for worker nodes.
 
 ```
 kubectl apply -f https://github.com/oracle/oci-flexvolume-driver/releases/download/${flexvolume_driver_version}/oci-flexvolume-driver.yaml
 ```
 
-You'll still need to add the config file as per below (we'll fix that with Instance Principals support soon).
+You'll still need to add the config file manually or as a kubernetes secret.
 
 ### Manually
 
@@ -61,6 +61,18 @@ auth:
 
 If `"region"` and/or `"compartment"` are not specified in the config file
 they will be retrieved from the hosts [OCI metadata service][4].
+
+### Submit configuration as a Kubernetes secret
+
+The configuration file above can be submitted as a Kubernetes Secret onto the master nodes.
+
+```
+kubectl create secret generic oci-flexvolume-driver \
+    -n kube-system \
+    --from-file=config.yaml=config.yaml
+```
+
+Once the Secret is set and the daemonsets deployed, the configuration file will be placed onto the master nodes.
 
 #### Extra configuration values
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -24,12 +24,21 @@ driver_dir="/flexmnt/$VENDOR${VENDOR:+"~"}${DRIVER}"
 
 LOG_FILE="$driver_dir/oci_flexvolume_driver.log"
 
+config_file_name="config.yaml"
+config_tmp_dir="/tmp"
+
+CONFIG_FILE="$config_tmp_dir/$config_file_name"
+
 if [ ! -d "$driver_dir" ]; then
   mkdir "$driver_dir"
 fi
 
 cp "/$DRIVER" "$driver_dir/.$DRIVER"
 mv -f "$driver_dir/.$DRIVER" "$driver_dir/$DRIVER"
+
+if [ -f "$CONFIG_FILE" ]; then
+  cp  "$CONFIG_FILE"  "$driver_dir/$config_file_name"
+fi
 
 while : ; do
   touch $LOG_FILE

--- a/manifests/oci-flexvolume-driver.yaml
+++ b/manifests/oci-flexvolume-driver.yaml
@@ -1,20 +1,60 @@
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
-  name: oci-flexvolume-driver
+  name: oci-flexvolume-driver-master
   namespace: kube-system
 spec:
   template:
     metadata:
-      name: oci-flexvolume-driver
+      name: oci-flexvolume-driver-master
       labels:
         app: oci-flexvolume-driver
     spec:
+      nodeSelector:
+        node-role.kubernetes.io/master: "true"
       tolerations:
-        - key: node-role.kubernetes.io/master
-          effect: NoSchedule
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        value: "true"
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
       containers:
         - image: iad.ocir.io/__DOCKER_REGISTRY_USERNAME__/oci-flexvolume-driver:__VERSION__
+          imagePullPolicy: Always
+          name: oci-flexvolume-driver
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /flexmnt
+              name: flexvolume-mount
+            - mountPath: /tmp
+              name: config
+              readOnly: true
+      volumes:
+        - name: flexvolume-mount
+          hostPath:
+            path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/
+            type: DirectoryOrCreate
+        - name: config
+          secret:
+            secretName: oci-flexvolume-driver
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: oci-flexvolume-driver-worker
+  namespace: kube-system
+spec:
+  template:
+    metadata:
+      name: oci-flexvolume-driver-worker
+      labels:
+        app: oci-flexvolume-driver
+    spec:
+      containers:
+        - image: iad.ocir.io/__DOCKER_REGISTRY_USERNAME__/oci-flexvolume-driver:__VERSION__
+          imagePullPolicy: Always
           name: oci-flexvolume-driver
           securityContext:
             privileged: true


### PR DESCRIPTION
Fix: #109 

Splits the daemon set into two: one for the master nodes and one for the worker nodes. The configuration file can be configured in a secret which is then placed on the master nodes.

`kubectl create secret generic oci-flexvolume-driver \
    -n kube-system \
    --from-file=config.yaml=config.yaml`