### PR TITLE
Support using symlinks to find correct driver

### DIFF
--- a/cmd/oci/main.go
+++ b/cmd/oci/main.go
@@ -50,5 +50,10 @@ func main() {
 	log.SetOutput(f)
 
 	log.Printf("OCI FlexVolume Driver version: %s (%s)", version, build)
-	flexvolume.ExecDriver(&driver.OCIFlexvolumeDriver{}, os.Args)
+
+	drivers := map[string]flexvolume.Driver{
+		"oci-bvs": &driver.OCIFlexvolumeDriver{},
+	}
+
+	flexvolume.ExecDriver(drivers, os.Args)
 }

--- a/deploy.sh
+++ b/deploy.sh
@@ -20,7 +20,9 @@ set -o pipefail
 VENDOR=oracle
 DRIVER=oci
 
-driver_dir="/flexmnt/$VENDOR${VENDOR:+"~"}${DRIVER}"
+ORACLE_OCI_FOLDER=$VENDOR${VENDOR:+"~"}${DRIVER}
+
+driver_dir="/flexmnt/$ORACLE_OCI_FOLDER"
 
 LOG_FILE="$driver_dir/oci_flexvolume_driver.log"
 
@@ -33,8 +35,14 @@ if [ ! -d "$driver_dir" ]; then
   mkdir "$driver_dir"
 fi
 
+if [ ! -d "$driver_dir-bvs" ]; then
+  mkdir "$driver_dir-bvs"
+fi
+
 cp "/$DRIVER" "$driver_dir/.$DRIVER"
 mv -f "$driver_dir/.$DRIVER" "$driver_dir/$DRIVER"
+
+ln -sf "../$ORACLE_OCI_FOLDER/$DRIVER" "$driver_dir-bvs/$DRIVER-bvs"
 
 if [ -f "$CONFIG_FILE" ]; then
   cp  "$CONFIG_FILE"  "$driver_dir/$config_file_name"

--- a/manifests/oci-flexvolume-driver.yaml
+++ b/manifests/oci-flexvolume-driver.yaml
@@ -11,7 +11,7 @@ spec:
         app: oci-flexvolume-driver
     spec:
       nodeSelector:
-        node-role.kubernetes.io/master: "true"
+        node-role.kubernetes.io/master: ""
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         value: "true"
@@ -20,7 +20,7 @@ spec:
         operator: Exists
         effect: NoSchedule
       containers:
-        - image: iad.ocir.io/__DOCKER_REGISTRY_USERNAME__/oci-flexvolume-driver:__VERSION__
+        - image: iad.ocir.io/__DOCKER_REGISTRY_TENANCY__/oci-flexvolume-driver:__VERSION__
           imagePullPolicy: Always
           name: oci-flexvolume-driver
           securityContext:
@@ -53,7 +53,7 @@ spec:
         app: oci-flexvolume-driver
     spec:
       containers:
-        - image: iad.ocir.io/__DOCKER_REGISTRY_USERNAME__/oci-flexvolume-driver:__VERSION__
+        - image: iad.ocir.io/__DOCKER_REGISTRY_TENANCY__/oci-flexvolume-driver:__VERSION__
           imagePullPolicy: Always
           name: oci-flexvolume-driver
           securityContext:

--- a/pkg/flexvolume/flexvolume.go
+++ b/pkg/flexvolume/flexvolume.go
@@ -149,6 +149,25 @@ func ExecDriver(driver Driver, args []string) DriverStatus {
 
 	log.Printf("'%s %s' called with %s", args[0], args[1], args[2:])
 
+<<<<<<< HEAD
+=======
+	driver := drivers[DefaultSymlinkDirectory] //Block volume is default
+
+	dir := path.Base(args[0])
+	dir = string(strings.TrimPrefix(dir, "oracle~"))
+
+	if dir != "oci" && dir != DefaultSymlinkDirectory {
+		driver = drivers[dir]
+	}
+
+	// Moved outside the above if to catch errors in code.
+	if driver == nil {
+		return Failf("No driver found for %s", dir)
+	}
+
+	log.Printf("Using %s driver", dir)
+
+>>>>>>> Add tests
 	switch args[1] {
 	// <driver executable> init
 	case "init":
@@ -265,5 +284,4 @@ func ExecDriver(driver Driver, args []string) DriverStatus {
 	default:
 		return Failf("invalid command; got ", args)
 	}
-	return Failf("Unexpected condition")
 }

--- a/pkg/flexvolume/flexvolume.go
+++ b/pkg/flexvolume/flexvolume.go
@@ -84,26 +84,6 @@ type Driver interface {
 	Unmount(mountDir string) DriverStatus
 }
 
-// ExitWithResult outputs the given Result and exits with the appropriate exit
-// code.
-func ExitWithResult(result DriverStatus) {
-	code := 1
-	if result.Status == StatusSuccess || result.Status == StatusNotSupported {
-		code = 0
-	}
-
-	res, err := json.Marshal(result)
-	if err != nil {
-		log.Printf("Error marshaling result: %v", err)
-		fmt.Fprintln(out, `{"status":"Failure","message":"Error marshaling result to JSON"}`)
-	} else {
-		s := string(res)
-		log.Printf("Command result: %s", s)
-		fmt.Fprintln(out, s)
-	}
-	exit(code)
-}
-
 // Fail creates a StatusFailure Result with a given message.
 func Fail(a ...interface{}) DriverStatus {
 	msg := fmt.Sprint(a...)
@@ -285,4 +265,5 @@ func ExecDriver(driver Driver, args []string) DriverStatus {
 	default:
 		return Failf("invalid command; got ", args)
 	}
+	return Failf("Unexpected condition")
 }

--- a/pkg/flexvolume/flexvolume.go
+++ b/pkg/flexvolume/flexvolume.go
@@ -169,28 +169,6 @@ func ExecDriver(driver Driver, args []string) DriverStatus {
 
 	log.Printf("'%s %s' called with %s", args[0], args[1], args[2:])
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-	driver := drivers[DefaultSymlinkDirectory] //Block volume is default
-
-	dir := path.Base(args[0])
-	dir = string(strings.TrimPrefix(dir, "oracle~"))
-
-	if dir != "oci" && dir != DefaultSymlinkDirectory {
-		driver = drivers[dir]
-	}
-
-	// Moved outside the above if to catch errors in code.
-	if driver == nil {
-		return Failf("No driver found for %s", dir)
-	}
-
-	log.Printf("Using %s driver", dir)
-
->>>>>>> Add tests
-=======
->>>>>>> Review changes
 	switch args[1] {
 	// <driver executable> init
 	case "init":

--- a/pkg/flexvolume/flexvolume.go
+++ b/pkg/flexvolume/flexvolume.go
@@ -154,7 +154,7 @@ func ExecDriver(drivers map[string]Driver, args []string) DriverStatus {
 	driver := drivers[DefaultSymlinkDirectory] //Block volume is default
 
 	dir := path.Base(args[0])
-	dir = strings.TrimPrefix(dir, "oracle~")
+	dir = string(strings.TrimPrefix(dir, "oracle~"))
 
 	if dir != "oci" && dir != DefaultSymlinkDirectory {
 		driver = drivers[dir]
@@ -162,7 +162,7 @@ func ExecDriver(drivers map[string]Driver, args []string) DriverStatus {
 
 	// Moved outside the above if to catch errors in code.
 	if driver == nil {
-		Failf("No driver found for ", dir)
+		return Failf("No driver found for %s", dir)
 	}
 
 	log.Printf("Using %s driver", dir)
@@ -283,5 +283,4 @@ func ExecDriver(drivers map[string]Driver, args []string) DriverStatus {
 	default:
 		return Failf("invalid command; got ", args)
 	}
-	return Failf("Unexpected condition")
 }

--- a/pkg/flexvolume/flexvolume.go
+++ b/pkg/flexvolume/flexvolume.go
@@ -84,6 +84,26 @@ type Driver interface {
 	Unmount(mountDir string) DriverStatus
 }
 
+// ExitWithResult outputs the given Result and exits with the appropriate exit
+// code.
+func ExitWithResult(result DriverStatus) {
+	code := 1
+	if result.Status == StatusSuccess || result.Status == StatusNotSupported {
+		code = 0
+	}
+
+	res, err := json.Marshal(result)
+	if err != nil {
+		log.Printf("Error marshaling result: %v", err)
+		fmt.Fprintln(out, `{"status":"Failure","message":"Error marshaling result to JSON"}`)
+	} else {
+		s := string(res)
+		log.Printf("Command result: %s", s)
+		fmt.Fprintln(out, s)
+	}
+	exit(code)
+}
+
 // Fail creates a StatusFailure Result with a given message.
 func Fail(a ...interface{}) DriverStatus {
 	msg := fmt.Sprint(a...)
@@ -150,6 +170,7 @@ func ExecDriver(driver Driver, args []string) DriverStatus {
 	log.Printf("'%s %s' called with %s", args[0], args[1], args[2:])
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
 	driver := drivers[DefaultSymlinkDirectory] //Block volume is default
 
@@ -168,6 +189,8 @@ func ExecDriver(driver Driver, args []string) DriverStatus {
 	log.Printf("Using %s driver", dir)
 
 >>>>>>> Add tests
+=======
+>>>>>>> Review changes
 	switch args[1] {
 	// <driver executable> init
 	case "init":

--- a/pkg/flexvolume/flexvolume.go
+++ b/pkg/flexvolume/flexvolume.go
@@ -86,29 +86,18 @@ type Driver interface {
 	Unmount(mountDir string) DriverStatus
 }
 
-// ExitWithResult outputs the given Result and exits with the appropriate exit
-// code.
-func ExitWithResult(result DriverStatus) {
-	code := 1
-	if result.Status == StatusSuccess || result.Status == StatusNotSupported {
-		code = 0
-	}
-
-	res, err := json.Marshal(result)
-	if err != nil {
-		log.Printf("Error marshaling result: %v", err)
-		fmt.Fprintln(out, `{"status":"Failure","message":"Error marshaling result to JSON"}`)
-	} else {
-		s := string(res)
-		log.Printf("Command result: %s", s)
-		fmt.Fprintln(out, s)
-	}
-	exit(code)
-}
-
 // Fail creates a StatusFailure Result with a given message.
 func Fail(a ...interface{}) DriverStatus {
 	msg := fmt.Sprint(a...)
+	return DriverStatus{
+		Status:  StatusFailure,
+		Message: msg,
+	}
+}
+
+// Failf creates a StatusFailure Result with a given message.
+func Failf(s string, a ...interface{}) DriverStatus {
+	msg := fmt.Sprintf(s, a...)
 	return DriverStatus{
 		Status:  StatusFailure,
 		Message: msg,
@@ -120,6 +109,14 @@ func Succeed(a ...interface{}) DriverStatus {
 	return DriverStatus{
 		Status:  StatusSuccess,
 		Message: fmt.Sprint(a...),
+	}
+}
+
+// NotSupportedf creates a StatusNotSupported Result with a given message.
+func NotSupportedf(s string, a ...interface{}) DriverStatus {
+	return DriverStatus{
+		Status:  StatusNotSupported,
+		Message: fmt.Sprintf(s, a...),
 	}
 }
 
@@ -147,9 +144,9 @@ func processOpts(optsStr string) (Options, error) {
 
 // ExecDriver executes the appropriate FlexvolumeDriver command based on
 // recieved call-out.
-func ExecDriver(drivers map[string]Driver, args []string) {
+func ExecDriver(drivers map[string]Driver, args []string) DriverStatus {
 	if len(args) < 2 {
-		ExitWithResult(Fail("Expected at least one argument"))
+		return Failf("Expected at least one argument")
 	}
 
 	log.Printf("'%s %s' called with %s", args[0], args[1], args[2:])
@@ -161,9 +158,11 @@ func ExecDriver(drivers map[string]Driver, args []string) {
 
 	if dir != "oci" && dir != DefaultSymlinkDirectory {
 		driver = drivers[dir]
-		if driver == nil {
-			ExitWithResult(Fail("No driver found for ", dir))
-		}
+	}
+
+	// Moved outside the above if to catch errors in code.
+	if driver == nil {
+		Failf("No driver found for ", dir)
 	}
 
 	log.Printf("Using %s driver", dir)
@@ -171,7 +170,7 @@ func ExecDriver(drivers map[string]Driver, args []string) {
 	switch args[1] {
 	// <driver executable> init
 	case "init":
-		ExitWithResult(driver.Init())
+		return driver.Init()
 
 	// <driver executable> getvolumename <json options>
 	// Currently broken as of lates kube release (1.6.4). Work around hardcodes
@@ -179,63 +178,63 @@ func ExecDriver(drivers map[string]Driver, args []string) {
 	// TODO(apryde): Investigate current situation and version support
 	// requirements.
 	case "getvolumename":
-		ExitWithResult(NotSupported("getvolumename is broken as of kube 1.6.4"))
+		return NotSupportedf("getvolumename is broken as of kube 1.6.4")
 
 	// <driver executable> attach <json options> <node name>
 	case "attach":
 		if len(args) != 4 {
-			ExitWithResult(Fail("attach expected exactly 4 arguments; got ", args))
+			Failf("attach expected exactly 4 arguments; got ", args)
 		}
 
 		opts, err := processOpts(args[2])
 		if err != nil {
-			ExitWithResult(Fail(err))
+			return Failf(err.Error())
 		}
 
 		nodeName := args[3]
-		ExitWithResult(driver.Attach(opts, nodeName))
+		return driver.Attach(opts, nodeName)
 
 	// <driver executable> detach <mount device> <node name>
 	case "detach":
 		if len(args) != 4 {
-			ExitWithResult(Fail("detach expected exactly 4 arguments; got ", args))
+			return Failf("detach expected exactly 4 arguments; got ", args)
 		}
 
 		mountDevice := args[2]
 		nodeName := args[3]
-		ExitWithResult(driver.Detach(mountDevice, nodeName))
+		return driver.Detach(mountDevice, nodeName)
 
 	// <driver executable> waitforattach <mount device> <json options>
 	case "waitforattach":
 		if len(args) != 4 {
-			ExitWithResult(Fail("waitforattach expected exactly 4 arguments; got ", args))
+			return Failf("waitforattach expected exactly 4 arguments; got ", args)
 		}
 
 		mountDevice := args[2]
 		opts, err := processOpts(args[3])
 		if err != nil {
-			ExitWithResult(Fail(err))
+			return Failf(err.Error())
 		}
 
-		ExitWithResult(driver.WaitForAttach(mountDevice, opts))
+		return driver.WaitForAttach(mountDevice, opts)
 
 	// <driver executable> isattached <json options> <node name>
 	case "isattached":
 		if len(args) != 4 {
-			ExitWithResult(Fail("isattached expected exactly 4 arguments; got ", args))
+			return Failf("isattached expected exactly 4 arguments; got ", args)
 		}
 
 		opts, err := processOpts(args[2])
 		if err != nil {
-			ExitWithResult(Fail(err))
+			return Failf(err.Error())
 		}
 		nodeName := args[3]
-		ExitWithResult(driver.IsAttached(opts, nodeName))
+		return driver.IsAttached(opts, nodeName)
 
 	// <driver executable> mountdevice <mount dir> <mount device> <json options>
 	case "mountdevice":
 		if len(args) != 5 {
-			ExitWithResult(Fail("mountdevice expected exactly 5 arguments; got ", args))
+			return Failf("mountdevice expected exactly 5 arguments; got ", args)
 		}
 
 		mountDir := args[2]
@@ -243,45 +242,46 @@ func ExecDriver(drivers map[string]Driver, args []string) {
 
 		opts, err := processOpts(args[4])
 		if err != nil {
-			ExitWithResult(Fail(err))
+			return Failf(err.Error())
 		}
 
-		ExitWithResult(driver.MountDevice(mountDir, mountDevice, opts))
+		return driver.MountDevice(mountDir, mountDevice, opts)
 
 	// <driver executable> unmountdevice <mount dir>
 	case "unmountdevice":
 		if len(args) != 3 {
-			ExitWithResult(Fail("unmountdevice expected exactly 3 arguments; got ", args))
+			return Failf("unmountdevice expected exactly 3 arguments; got ", args)
 		}
 
 		mountDir := args[2]
-		ExitWithResult(driver.UnmountDevice(mountDir))
+		return driver.UnmountDevice(mountDir)
 
 	// <driver executable> mount <mount dir> <json options>
 	case "mount":
 		if len(args) != 4 {
-			ExitWithResult(Fail("mount expected exactly 4 arguments; got ", args))
+			return Failf("mount expected exactly 4 arguments; got ", args)
 		}
 
 		mountDir := args[2]
 
 		opts, err := processOpts(args[3])
 		if err != nil {
-			ExitWithResult(Fail(err))
+			return Failf(err.Error())
 		}
 
-		ExitWithResult(driver.Mount(mountDir, opts))
+		return driver.Mount(mountDir, opts)
 
 	// <driver executable> unmount <mount dir>
 	case "unmount":
 		if len(args) != 3 {
-			ExitWithResult(Fail("mount expected exactly 3 arguments; got ", args))
+			return Failf("mount expected exactly 3 arguments; got ", args)
 		}
 
 		mountDir := args[2]
-		ExitWithResult(driver.Unmount(mountDir))
+		return driver.Unmount(mountDir)
 
 	default:
-		ExitWithResult(Fail("Invalid command; got ", args))
+		return Failf("invalid command; got ", args)
 	}
+	return Failf("Unexpected condition")
 }

--- a/pkg/flexvolume/flexvolume.go
+++ b/pkg/flexvolume/flexvolume.go
@@ -84,26 +84,6 @@ type Driver interface {
 	Unmount(mountDir string) DriverStatus
 }
 
-// ExitWithResult outputs the given Result and exits with the appropriate exit
-// code.
-func ExitWithResult(result DriverStatus) {
-	code := 1
-	if result.Status == StatusSuccess || result.Status == StatusNotSupported {
-		code = 0
-	}
-
-	res, err := json.Marshal(result)
-	if err != nil {
-		log.Printf("Error marshaling result: %v", err)
-		fmt.Fprintln(out, `{"status":"Failure","message":"Error marshaling result to JSON"}`)
-	} else {
-		s := string(res)
-		log.Printf("Command result: %s", s)
-		fmt.Fprintln(out, s)
-	}
-	exit(code)
-}
-
 // Fail creates a StatusFailure Result with a given message.
 func Fail(a ...interface{}) DriverStatus {
 	msg := fmt.Sprint(a...)

--- a/pkg/flexvolume/flexvolume.go
+++ b/pkg/flexvolume/flexvolume.go
@@ -84,6 +84,26 @@ type Driver interface {
 	Unmount(mountDir string) DriverStatus
 }
 
+// ExitWithResult outputs the given Result and exits with the appropriate exit
+// code.
+func ExitWithResult(result DriverStatus) {
+	code := 1
+	if result.Status == StatusSuccess || result.Status == StatusNotSupported {
+		code = 0
+	}
+
+	res, err := json.Marshal(result)
+	if err != nil {
+		log.Printf("Error marshaling result: %v", err)
+		fmt.Fprintln(out, `{"status":"Failure","message":"Error marshaling result to JSON"}`)
+	} else {
+		s := string(res)
+		log.Printf("Command result: %s", s)
+		fmt.Fprintln(out, s)
+	}
+	exit(code)
+}
+
 // Fail creates a StatusFailure Result with a given message.
 func Fail(a ...interface{}) DriverStatus {
 	msg := fmt.Sprint(a...)

--- a/pkg/flexvolume/flexvolume_test.go
+++ b/pkg/flexvolume/flexvolume_test.go
@@ -31,7 +31,7 @@ func TestInit(t *testing.T) {
 	exit = func(c int) { code = c }
 	defer func() { exit = osexit }()
 
-	ExecDriver(mockFlexvolumeDriver{}, []string{"oci", "init"})
+	ExecDriver(map[string]Driver{"oci-bvs": mockFlexvolumeDriver{}}, []string{"oci", "init"})
 
 	if out.(*bytes.Buffer).String() != `{"status":"Success"}`+"\n" {
 		t.Fatalf(`Expected '{"status":"Success"}'; got %s`, out.(*bytes.Buffer).String())
@@ -55,7 +55,7 @@ func TestGetVolumeName(t *testing.T) {
 	exit = func(c int) { code = c }
 	defer func() { exit = osexit }()
 
-	ExecDriver(mockFlexvolumeDriver{}, []string{"oci", "getvolumename", defaultTestOps})
+	ExecDriver(map[string]Driver{"oci-bvs": mockFlexvolumeDriver{}}, []string{"oci", "getvolumename", defaultTestOps})
 
 	if out.(*bytes.Buffer).String() != `{"status":"Not supported","message":"getvolumename is broken as of kube 1.6.4"}`+"\n" {
 		t.Fatalf(`Expected '{"status":"Not supported","message":"getvolumename is broken as of kube 1.6.4"}}'; got %s`, out.(*bytes.Buffer).String())
@@ -76,7 +76,7 @@ func TestAttachUnsuported(t *testing.T) {
 	exit = func(c int) { code = c }
 	defer func() { exit = osexit }()
 
-	ExecDriver(mockFlexvolumeDriver{}, []string{"oci", "attach", defaultTestOps, "nodeName"})
+	ExecDriver(map[string]Driver{"oci-bvs": mockFlexvolumeDriver{}}, []string{"oci", "attach", defaultTestOps, "nodeName"})
 
 	if out.(*bytes.Buffer).String() != `{"status":"Not supported"}`+"\n" {
 		t.Fatalf(`Expected '{"status":"Not supported""}'; got %s`, out.(*bytes.Buffer).String())

--- a/pkg/flexvolume/flexvolume_test.go
+++ b/pkg/flexvolume/flexvolume_test.go
@@ -34,7 +34,8 @@ func assertFailure(t *testing.T, expected DriverStatus, status DriverStatus) {
 }
 
 func TestInit(t *testing.T) {
-	status := ExecDriver(map[string]Driver{"oci-bvs": mockFlexvolumeDriver{}},
+	status := ExecDriver(
+		mockFlexvolumeDriver{},
 		[]string{"oci", "init"})
 
 	expected := DriverStatus{Status: "Success"}
@@ -46,8 +47,10 @@ func TestInit(t *testing.T) {
 // StatusNotSupported as the call-out is broken as of the latest stable Kube
 // release (1.6.4).
 func TestGetVolumeName(t *testing.T) {
-	status := ExecDriver(map[string]Driver{"oci-bvs": mockFlexvolumeDriver{}},
-		[]string{"oci", "getvolumename", defaultTestOps})
+	status := ExecDriver(
+		mockFlexvolumeDriver{},
+		[]string{"oci", "getvolumename", defaultTestOps},
+	)
 
 	expected := DriverStatus{Status: "Not supported", Message: "getvolumename is broken as of kube 1.6.4"}
 
@@ -55,7 +58,8 @@ func TestGetVolumeName(t *testing.T) {
 }
 
 func TestNoVolumeIDDispatch(t *testing.T) {
-	status := ExecDriver(map[string]Driver{"oci-bvs": mockFlexvolumeDriver{}},
+	status := ExecDriver(
+		mockFlexvolumeDriver{},
 		[]string{"oci", "attach", noVolIDTestOps, "nodeName"})
 
 	expected := DriverStatus{
@@ -65,20 +69,10 @@ func TestNoVolumeIDDispatch(t *testing.T) {
 }
 
 func TestAttachUnsuported(t *testing.T) {
-	status := ExecDriver(map[string]Driver{"oci-bvs": mockFlexvolumeDriver{}},
+	status := ExecDriver(
+		mockFlexvolumeDriver{},
 		[]string{"oci", "attach", defaultTestOps, "nodeName"})
 
 	expected := DriverStatus{Status: "Not supported"}
-	assertFailure(t, expected, status)
-}
-
-func TestInvalidSymlink(t *testing.T) {
-	status := ExecDriver(map[string]Driver{"oci-bvs": mockFlexvolumeDriver{}},
-		[]string{"oci-abc", "init", defaultTestOps, "nodeName"})
-
-	expected := DriverStatus{
-		Status:  "Failure",
-		Message: "No driver found for oci-abc",
-	}
 	assertFailure(t, expected, status)
 }

--- a/pkg/flexvolume/flexvolume_test.go
+++ b/pkg/flexvolume/flexvolume_test.go
@@ -59,8 +59,7 @@ func TestNoVolumeIDDispatch(t *testing.T) {
 		[]string{"oci", "attach", noVolIDTestOps, "nodeName"})
 
 	expected := DriverStatus{
-		Status:  "Failure",
-		Message: "key 'kubernetes.io/pvOrVolumeName' not found in attach options",
+		Status: "Not supported",
 	}
 	assertFailure(t, expected, status)
 }

--- a/pkg/flexvolume/flexvolume_test.go
+++ b/pkg/flexvolume/flexvolume_test.go
@@ -72,3 +72,14 @@ func TestAttachUnsuported(t *testing.T) {
 	expected := DriverStatus{Status: "Not supported"}
 	assertFailure(t, expected, status)
 }
+
+func TestInvalidSymlink(t *testing.T) {
+	status := ExecDriver(map[string]Driver{"oci-bvs": mockFlexvolumeDriver{}},
+		[]string{"oci-abc", "init", defaultTestOps, "nodeName"})
+
+	expected := DriverStatus{
+		Status:  "Failure",
+		Message: "No driver found for oci-abc",
+	}
+	assertFailure(t, expected, status)
+}

--- a/pkg/flexvolume/flexvolume_test.go
+++ b/pkg/flexvolume/flexvolume_test.go
@@ -76,14 +76,3 @@ func TestAttachUnsuported(t *testing.T) {
 	expected := DriverStatus{Status: "Not supported"}
 	assertFailure(t, expected, status)
 }
-
-func TestInvalidSymlink(t *testing.T) {
-	status := ExecDriver(map[string]Driver{"oci-bvs": mockFlexvolumeDriver{}},
-		[]string{"oci-abc", "init", defaultTestOps, "nodeName"})
-
-	expected := DriverStatus{
-		Status:  "Failure",
-		Message: "No driver found for oci-abc",
-	}
-	assertFailure(t, expected, status)
-}

--- a/pkg/flexvolume/flexvolume_test.go
+++ b/pkg/flexvolume/flexvolume_test.go
@@ -76,3 +76,14 @@ func TestAttachUnsuported(t *testing.T) {
 	expected := DriverStatus{Status: "Not supported"}
 	assertFailure(t, expected, status)
 }
+
+func TestInvalidSymlink(t *testing.T) {
+	status := ExecDriver(map[string]Driver{"oci-bvs": mockFlexvolumeDriver{}},
+		[]string{"oci-abc", "init", defaultTestOps, "nodeName"})
+
+	expected := DriverStatus{
+		Status:  "Failure",
+		Message: "No driver found for oci-abc",
+	}
+	assertFailure(t, expected, status)
+}

--- a/pkg/flexvolume/flexvolume_test.go
+++ b/pkg/flexvolume/flexvolume_test.go
@@ -15,74 +15,60 @@
 package flexvolume
 
 import (
-	"bytes"
 	"testing"
 )
 
-const defaultTestOps = `{"kubernetes.io/fsType":"ext4","kubernetes.io/readwrite":"rw"}`
+const defaultTestOps = `{"kubernetes.io/fsType":"ext4","kubernetes.io/readwrite":"rw","kubernetes.io/pvOrVolumeName":"mockvolumeid"}`
+const noVolIDTestOps = `{"kubernetes.io/fsType":"ext4","kubernetes.io/readwrite":"rw"}`
+
+func assertSuccess(t *testing.T, expected DriverStatus, status DriverStatus) {
+	if status != expected {
+		t.Fatalf(`Expected '%#v' got '%#v'`, expected, status)
+	}
+}
+
+func assertFailure(t *testing.T, expected DriverStatus, status DriverStatus) {
+	if status != expected {
+		t.Fatalf(`Expected '%#v' got '%#v'`, expected, status)
+	}
+}
 
 func TestInit(t *testing.T) {
-	bak := out
-	out = new(bytes.Buffer)
-	defer func() { out = bak }()
+	status := ExecDriver(map[string]Driver{"oci-bvs": mockFlexvolumeDriver{}},
+		[]string{"oci", "init"})
 
-	code := 0
-	osexit := exit
-	exit = func(c int) { code = c }
-	defer func() { exit = osexit }()
+	expected := DriverStatus{Status: "Success"}
 
-	ExecDriver(map[string]Driver{"oci-bvs": mockFlexvolumeDriver{}}, []string{"oci", "init"})
-
-	if out.(*bytes.Buffer).String() != `{"status":"Success"}`+"\n" {
-		t.Fatalf(`Expected '{"status":"Success"}'; got %s`, out.(*bytes.Buffer).String())
-	}
-
-	if code != 0 {
-		t.Fatalf("Expected 'exit 0'; got 'exit %d'", code)
-	}
+	assertSuccess(t, expected, status)
 }
 
 // TestVolumeName tests that the getvolumename call-out results in
 // StatusNotSupported as the call-out is broken as of the latest stable Kube
 // release (1.6.4).
 func TestGetVolumeName(t *testing.T) {
-	bak := out
-	out = new(bytes.Buffer)
-	defer func() { out = bak }()
+	status := ExecDriver(map[string]Driver{"oci-bvs": mockFlexvolumeDriver{}},
+		[]string{"oci", "getvolumename", defaultTestOps})
 
-	code := 0
-	osexit := exit
-	exit = func(c int) { code = c }
-	defer func() { exit = osexit }()
+	expected := DriverStatus{Status: "Not supported", Message: "getvolumename is broken as of kube 1.6.4"}
 
-	ExecDriver(map[string]Driver{"oci-bvs": mockFlexvolumeDriver{}}, []string{"oci", "getvolumename", defaultTestOps})
+	assertFailure(t, expected, status)
+}
 
-	if out.(*bytes.Buffer).String() != `{"status":"Not supported","message":"getvolumename is broken as of kube 1.6.4"}`+"\n" {
-		t.Fatalf(`Expected '{"status":"Not supported","message":"getvolumename is broken as of kube 1.6.4"}}'; got %s`, out.(*bytes.Buffer).String())
+func TestNoVolumeIDDispatch(t *testing.T) {
+	status := ExecDriver(map[string]Driver{"oci-bvs": mockFlexvolumeDriver{}},
+		[]string{"oci", "attach", noVolIDTestOps, "nodeName"})
+
+	expected := DriverStatus{
+		Status:  "Failure",
+		Message: "key 'kubernetes.io/pvOrVolumeName' not found in attach options",
 	}
-
-	if code != 0 {
-		t.Fatalf("Expected 'exit 0'; got 'exit %d'", code)
-	}
+	assertFailure(t, expected, status)
 }
 
 func TestAttachUnsuported(t *testing.T) {
-	bak := out
-	out = new(bytes.Buffer)
-	defer func() { out = bak }()
+	status := ExecDriver(map[string]Driver{"oci-bvs": mockFlexvolumeDriver{}},
+		[]string{"oci", "attach", defaultTestOps, "nodeName"})
 
-	code := 0
-	osexit := exit
-	exit = func(c int) { code = c }
-	defer func() { exit = osexit }()
-
-	ExecDriver(map[string]Driver{"oci-bvs": mockFlexvolumeDriver{}}, []string{"oci", "attach", defaultTestOps, "nodeName"})
-
-	if out.(*bytes.Buffer).String() != `{"status":"Not supported"}`+"\n" {
-		t.Fatalf(`Expected '{"status":"Not supported""}'; got %s`, out.(*bytes.Buffer).String())
-	}
-
-	if code != 0 {
-		t.Fatalf("Expected 'exit 0'; got 'exit %d'", code)
-	}
+	expected := DriverStatus{Status: "Not supported"}
+	assertFailure(t, expected, status)
 }

--- a/test/integration/terraform/instance.tf
+++ b/test/integration/terraform/instance.tf
@@ -17,28 +17,30 @@ variable subnet_ocid {
 # Gets the OCID of the OS image to use
 data "oci_core_images" "os_image_ocid" {
   compartment_id = "${var.compartment_ocid}"
-  display_name   = "Oracle-Linux-7.4-2018.02.21-1"
+  display_name   = "Oracle-Linux-7.5-2018.05.09-1"
 }
 
 resource "oci_core_instance" "instance" {
   availability_domain = "${var.availability_domain}"
-  compartment_id = "${var.compartment_ocid}"
-  display_name = "${var.test_id}"
-  image = "${lookup(data.oci_core_images.os_image_ocid.images[0], "id")}"
-  shape = "VM.Standard1.1"
-  subnet_id =  "${var.subnet_ocid}"
+  compartment_id      = "${var.compartment_ocid}"
+  display_name        = "${var.test_id}"
+  image               = "${lookup(data.oci_core_images.os_image_ocid.images[0], "id")}"
+  shape               = "VM.Standard1.1"
+  subnet_id           = "${var.subnet_ocid}"
+
   metadata {
     ssh_authorized_keys = "${var.ssh_public_key}"
   }
+
   timeouts {
     create = "60m"
   }
 }
 
 data "oci_core_vnic_attachments" "instance_vnics" {
-  compartment_id = "${var.compartment_ocid}"
+  compartment_id      = "${var.compartment_ocid}"
   availability_domain = "${var.availability_domain}"
-  instance_id = "${oci_core_instance.instance.id}"
+  instance_id         = "${oci_core_instance.instance.id}"
 }
 
 # Gets the OCID of the first (default) vNIC
@@ -48,9 +50,10 @@ data "oci_core_vnic" "instance_vnic" {
 
 data "template_file" "driver_config" {
   template = "${file("${path.module}/config.yaml.tpl")}"
+
   vars {
-      key = "${ indent(4, file("${path.module}/_tmp/oci_api_key.pem")) }"
-      vcn = "${var.vcn}"
+    key = "${ indent(4, file("${path.module}/_tmp/oci_api_key.pem")) }"
+    vcn = "${var.vcn}"
   }
 }
 
@@ -60,13 +63,13 @@ resource null_resource "instance" {
   ]
 
   triggers {
-     instance_id = "${oci_core_instance.instance.id}"
+    instance_id = "${oci_core_instance.instance.id}"
   }
 
   connection {
-    type = "ssh"
-    host = "${data.oci_core_vnic.instance_vnic.public_ip_address}"
-    user = "opc"
+    type        = "ssh"
+    host        = "${data.oci_core_vnic.instance_vnic.public_ip_address}"
+    user        = "opc"
     private_key = "${var.ssh_private_key}"
   }
 
@@ -76,7 +79,7 @@ resource null_resource "instance" {
   }
 
   provisioner "file" "driver_config" {
-    content = "${data.template_file.driver_config.rendered}"
+    content     = "${data.template_file.driver_config.rendered}"
     destination = "/home/opc/config.yaml"
   }
 


### PR DESCRIPTION
Addresses https://github.com/oracle/oci-volume-provisioner/issues/131

The volume provisioner has been patched to now not use names to dispatch custom logic. A storage class can now use it's provisioner property to determine what driver should be used. At the moment only block volume storage is supported ```provisioner: oracle.com/oci-bvs``` with aim that file storage will soon be supported also https://github.com/oracle/oci-volume-provisioner/issues/90. Backwards compatible so that existing storage classes using ```provisioner: oracle.com/oci``` will default to using the block volume storage however this should be marked as deprecated and removed in a future release.