### PR TITLE
WIP: Support using symlinks to find correct driver

### DIFF
--- a/cmd/oci/main.go
+++ b/cmd/oci/main.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path"
+	"strings"
 
 	"github.com/oracle/oci-flexvolume-driver/pkg/flexvolume"
 	"github.com/oracle/oci-flexvolume-driver/pkg/oci/driver"
@@ -27,6 +29,13 @@ import (
 var version string
 var build string
 
+// DefaultDriver is the default flexvolume driver symlink extension.
+const DefaultDriver string = "oci-bvs"
+
+var (
+	drivers = make(map[string]flexvolume.Driver)
+)
+
 // GetLogPath returns the default path to the driver log file.
 func GetLogPath() string {
 	path := os.Getenv("OCI_FLEXD_DRIVER_LOG_DIR")
@@ -34,6 +43,10 @@ func GetLogPath() string {
 		path = driver.GetDriverDirectory()
 	}
 	return path + "/oci_flexvolume_driver.log"
+}
+
+func registerDrivers() {
+	registerDriver("oci-bvs", &driver.OCIFlexvolumeDriver{})
 }
 
 func main() {
@@ -50,5 +63,53 @@ func main() {
 	log.SetOutput(f)
 
 	log.Printf("OCI FlexVolume Driver version: %s (%s)", version, build)
-	flexvolume.ExecDriver(&driver.OCIFlexvolumeDriver{}, os.Args)
+
+	registerDrivers()
+
+	driver, err := getDriverFromArgs()
+	if err != nil {
+		log.Fatalf(err.Error())
+	}
+
+	flexvolume.ExitWithResult(flexvolume.ExecDriver(driver, os.Args))
+}
+
+func getDriverFromArgs() (flexvolume.Driver, error) {
+	driver, err := getDriver(DefaultDriver) //Block volume is default
+	if err != nil {
+		return nil, err
+	}
+
+	if len(os.Args) == 0 {
+		log.Printf("No arguments found, using default driver %s", DefaultDriver)
+		return driver, nil
+	}
+
+	dir := path.Base(os.Args[0])
+	dir = strings.TrimPrefix(dir, "oracle~")
+
+	if dir != "oci" && dir != DefaultDriver {
+		driver, err = getDriver(dir)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	log.Printf("Using %s driver", dir)
+
+	return driver, nil
+}
+
+func registerDriver(name string, driver flexvolume.Driver) {
+	if drivers[name] == nil {
+		drivers[name] = driver
+	}
+}
+
+func getDriver(name string) (flexvolume.Driver, error) {
+	driver, ok := drivers[name]
+	if !ok {
+		return nil, fmt.Errorf("could not find a registered driver for %s", name)
+	}
+	return driver, nil
 }

--- a/cmd/oci/main.go
+++ b/cmd/oci/main.go
@@ -31,7 +31,7 @@ var build string
 func GetLogPath() string {
 	path := os.Getenv("OCI_FLEXD_DRIVER_LOG_DIR")
 	if path == "" {
-		path = driver.GetDriverDirectory()
+		path = driver.GetDirectory()
 	}
 	return path + "/oci_flexvolume_driver.log"
 }
@@ -51,7 +51,7 @@ func main() {
 
 	log.Printf("OCI FlexVolume Driver version: %s (%s)", version, build)
 
-	driver, err := driver.GetDriver(driver.GetDriverName(os.Args))
+	driver, err := driver.Get(driver.NameFromArgs(os.Args))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error loading driver: %v", err)
 	}

--- a/deploy.sh
+++ b/deploy.sh
@@ -20,7 +20,9 @@ set -o pipefail
 VENDOR=oracle
 DRIVER=oci
 
-driver_dir="/flexmnt/$VENDOR${VENDOR:+"~"}${DRIVER}"
+ORACLE_OCI_FOLDER=$VENDOR${VENDOR:+"~"}${DRIVER}
+
+driver_dir="/flexmnt/$ORACLE_OCI_FOLDER"
 
 LOG_FILE="$driver_dir/oci_flexvolume_driver.log"
 
@@ -33,8 +35,14 @@ if [ ! -d "$driver_dir" ]; then
   mkdir "$driver_dir"
 fi
 
+if [ ! -d "$driver_dir-bvs" ]; then
+  mkdir "$driver_dir-bvs"
+fi
+
 cp "/$DRIVER" "$driver_dir/.$DRIVER"
 mv -f "$driver_dir/.$DRIVER" "$driver_dir/$DRIVER"
+
+ln -sf "../$ORACLE_OCI_FOLDER/$DRIVER" "$driver_dir-bvs/$DRIVER-bvs"
 
 if [ -f "$CONFIG_FILE" ]; then
   cp  "$CONFIG_FILE"  "$driver_dir/$config_file_name"

--- a/pkg/flexvolume/flexvolume.go
+++ b/pkg/flexvolume/flexvolume.go
@@ -111,11 +111,28 @@ func Fail(a ...interface{}) DriverStatus {
 	}
 }
 
+// Failf creates a StatusFailure Result with a given message.
+func Failf(s string, a ...interface{}) DriverStatus {
+	msg := fmt.Sprintf(s, a...)
+	return DriverStatus{
+		Status:  StatusFailure,
+		Message: msg,
+	}
+}
+
 // Succeed creates a StatusSuccess Result with a given message.
 func Succeed(a ...interface{}) DriverStatus {
 	return DriverStatus{
 		Status:  StatusSuccess,
 		Message: fmt.Sprint(a...),
+	}
+}
+
+// NotSupportedf creates a StatusNotSupported Result with a given message.
+func NotSupportedf(s string, a ...interface{}) DriverStatus {
+	return DriverStatus{
+		Status:  StatusNotSupported,
+		Message: fmt.Sprintf(s, a...),
 	}
 }
 
@@ -143,9 +160,9 @@ func processOpts(optsStr string) (Options, error) {
 
 // ExecDriver executes the appropriate FlexvolumeDriver command based on
 // recieved call-out.
-func ExecDriver(driver Driver, args []string) {
+func ExecDriver(driver Driver, args []string) DriverStatus {
 	if len(args) < 2 {
-		ExitWithResult(Fail("Expected at least one argument"))
+		return Failf("Expected at least one argument")
 	}
 
 	log.Printf("'%s %s' called with %s", args[0], args[1], args[2:])
@@ -153,7 +170,7 @@ func ExecDriver(driver Driver, args []string) {
 	switch args[1] {
 	// <driver executable> init
 	case "init":
-		ExitWithResult(driver.Init())
+		return driver.Init()
 
 	// <driver executable> getvolumename <json options>
 	// Currently broken as of lates kube release (1.6.4). Work around hardcodes
@@ -161,63 +178,63 @@ func ExecDriver(driver Driver, args []string) {
 	// TODO(apryde): Investigate current situation and version support
 	// requirements.
 	case "getvolumename":
-		ExitWithResult(NotSupported("getvolumename is broken as of kube 1.6.4"))
+		return NotSupportedf("getvolumename is broken as of kube 1.6.4")
 
 	// <driver executable> attach <json options> <node name>
 	case "attach":
 		if len(args) != 4 {
-			ExitWithResult(Fail("attach expected exactly 4 arguments; got ", args))
+			Failf("attach expected exactly 4 arguments; got %d ", len(args))
 		}
 
 		opts, err := processOpts(args[2])
 		if err != nil {
-			ExitWithResult(Fail(err))
+			return Failf(err.Error())
 		}
 
 		nodeName := args[3]
-		ExitWithResult(driver.Attach(opts, nodeName))
+		return driver.Attach(opts, nodeName)
 
 	// <driver executable> detach <mount device> <node name>
 	case "detach":
 		if len(args) != 4 {
-			ExitWithResult(Fail("detach expected exactly 4 arguments; got ", args))
+			return Failf("detach expected exactly 4 arguments; got ", args)
 		}
 
 		mountDevice := args[2]
 		nodeName := args[3]
-		ExitWithResult(driver.Detach(mountDevice, nodeName))
+		return driver.Detach(mountDevice, nodeName)
 
 	// <driver executable> waitforattach <mount device> <json options>
 	case "waitforattach":
 		if len(args) != 4 {
-			ExitWithResult(Fail("waitforattach expected exactly 4 arguments; got ", args))
+			return Failf("waitforattach expected exactly 4 arguments; got ", args)
 		}
 
 		mountDevice := args[2]
 		opts, err := processOpts(args[3])
 		if err != nil {
-			ExitWithResult(Fail(err))
+			return Failf(err.Error())
 		}
 
-		ExitWithResult(driver.WaitForAttach(mountDevice, opts))
+		return driver.WaitForAttach(mountDevice, opts)
 
 	// <driver executable> isattached <json options> <node name>
 	case "isattached":
 		if len(args) != 4 {
-			ExitWithResult(Fail("isattached expected exactly 4 arguments; got ", args))
+			return Failf("isattached expected exactly 4 arguments; got ", args)
 		}
 
 		opts, err := processOpts(args[2])
 		if err != nil {
-			ExitWithResult(Fail(err))
+			return Failf(err.Error())
 		}
 		nodeName := args[3]
-		ExitWithResult(driver.IsAttached(opts, nodeName))
+		return driver.IsAttached(opts, nodeName)
 
 	// <driver executable> mountdevice <mount dir> <mount device> <json options>
 	case "mountdevice":
 		if len(args) != 5 {
-			ExitWithResult(Fail("mountdevice expected exactly 5 arguments; got ", args))
+			return Failf("mountdevice expected exactly 5 arguments; got ", args)
 		}
 
 		mountDir := args[2]
@@ -225,45 +242,45 @@ func ExecDriver(driver Driver, args []string) {
 
 		opts, err := processOpts(args[4])
 		if err != nil {
-			ExitWithResult(Fail(err))
+			return Failf(err.Error())
 		}
 
-		ExitWithResult(driver.MountDevice(mountDir, mountDevice, opts))
+		return driver.MountDevice(mountDir, mountDevice, opts)
 
 	// <driver executable> unmountdevice <mount dir>
 	case "unmountdevice":
 		if len(args) != 3 {
-			ExitWithResult(Fail("unmountdevice expected exactly 3 arguments; got ", args))
+			return Failf("unmountdevice expected exactly 3 arguments; got ", args)
 		}
 
 		mountDir := args[2]
-		ExitWithResult(driver.UnmountDevice(mountDir))
+		return driver.UnmountDevice(mountDir)
 
 	// <driver executable> mount <mount dir> <json options>
 	case "mount":
 		if len(args) != 4 {
-			ExitWithResult(Fail("mount expected exactly 4 arguments; got ", args))
+			return Failf("mount expected exactly 4 arguments; got ", args)
 		}
 
 		mountDir := args[2]
 
 		opts, err := processOpts(args[3])
 		if err != nil {
-			ExitWithResult(Fail(err))
+			return Failf(err.Error())
 		}
 
-		ExitWithResult(driver.Mount(mountDir, opts))
+		return driver.Mount(mountDir, opts)
 
 	// <driver executable> unmount <mount dir>
 	case "unmount":
 		if len(args) != 3 {
-			ExitWithResult(Fail("mount expected exactly 3 arguments; got ", args))
+			return Failf("mount expected exactly 3 arguments; got ", args)
 		}
 
 		mountDir := args[2]
-		ExitWithResult(driver.Unmount(mountDir))
+		return driver.Unmount(mountDir)
 
 	default:
-		ExitWithResult(Fail("Invalid command; got ", args))
+		return Failf("invalid command; got ", args)
 	}
 }

--- a/pkg/flexvolume/flexvolume_test.go
+++ b/pkg/flexvolume/flexvolume_test.go
@@ -15,74 +15,52 @@
 package flexvolume
 
 import (
-	"bytes"
 	"testing"
 )
 
-const defaultTestOps = `{"kubernetes.io/fsType":"ext4","kubernetes.io/readwrite":"rw"}`
+const defaultTestOps = `{"kubernetes.io/fsType":"ext4","kubernetes.io/readwrite":"rw","kubernetes.io/pvOrVolumeName":"mockvolumeid"}`
+const noVolIDTestOps = `{"kubernetes.io/fsType":"ext4","kubernetes.io/readwrite":"rw"}`
+
+func assertSuccess(t *testing.T, expected DriverStatus, status DriverStatus) {
+	if status != expected {
+		t.Fatalf(`Expected '%#v' got '%#v'`, expected, status)
+	}
+}
+
+func assertFailure(t *testing.T, expected DriverStatus, status DriverStatus) {
+	if status != expected {
+		t.Fatalf(`Expected '%#v' got '%#v'`, expected, status)
+	}
+}
 
 func TestInit(t *testing.T) {
-	bak := out
-	out = new(bytes.Buffer)
-	defer func() { out = bak }()
-
-	code := 0
-	osexit := exit
-	exit = func(c int) { code = c }
-	defer func() { exit = osexit }()
-
-	ExecDriver(mockFlexvolumeDriver{}, []string{"oci", "init"})
-
-	if out.(*bytes.Buffer).String() != `{"status":"Success"}`+"\n" {
-		t.Fatalf(`Expected '{"status":"Success"}'; got %s`, out.(*bytes.Buffer).String())
-	}
-
-	if code != 0 {
-		t.Fatalf("Expected 'exit 0'; got 'exit %d'", code)
-	}
+	status := ExecDriver(mockFlexvolumeDriver{}, []string{"oci", "init"})
+	expected := DriverStatus{Status: "Success"}
+	assertSuccess(t, expected, status)
 }
 
 // TestVolumeName tests that the getvolumename call-out results in
 // StatusNotSupported as the call-out is broken as of the latest stable Kube
 // release (1.6.4).
 func TestGetVolumeName(t *testing.T) {
-	bak := out
-	out = new(bytes.Buffer)
-	defer func() { out = bak }()
+	status := ExecDriver(
+		mockFlexvolumeDriver{},
+		[]string{"oci", "getvolumename", defaultTestOps},
+	)
+	expected := DriverStatus{Status: "Not supported", Message: "getvolumename is broken as of kube 1.6.4"}
+	assertFailure(t, expected, status)
+}
 
-	code := 0
-	osexit := exit
-	exit = func(c int) { code = c }
-	defer func() { exit = osexit }()
-
-	ExecDriver(mockFlexvolumeDriver{}, []string{"oci", "getvolumename", defaultTestOps})
-
-	if out.(*bytes.Buffer).String() != `{"status":"Not supported","message":"getvolumename is broken as of kube 1.6.4"}`+"\n" {
-		t.Fatalf(`Expected '{"status":"Not supported","message":"getvolumename is broken as of kube 1.6.4"}}'; got %s`, out.(*bytes.Buffer).String())
+func TestNoVolumeIDDispatch(t *testing.T) {
+	status := ExecDriver(mockFlexvolumeDriver{}, []string{"oci", "attach", noVolIDTestOps, "nodeName"})
+	expected := DriverStatus{
+		Status: "Not supported",
 	}
-
-	if code != 0 {
-		t.Fatalf("Expected 'exit 0'; got 'exit %d'", code)
-	}
+	assertFailure(t, expected, status)
 }
 
 func TestAttachUnsuported(t *testing.T) {
-	bak := out
-	out = new(bytes.Buffer)
-	defer func() { out = bak }()
-
-	code := 0
-	osexit := exit
-	exit = func(c int) { code = c }
-	defer func() { exit = osexit }()
-
-	ExecDriver(mockFlexvolumeDriver{}, []string{"oci", "attach", defaultTestOps, "nodeName"})
-
-	if out.(*bytes.Buffer).String() != `{"status":"Not supported"}`+"\n" {
-		t.Fatalf(`Expected '{"status":"Not supported""}'; got %s`, out.(*bytes.Buffer).String())
-	}
-
-	if code != 0 {
-		t.Fatalf("Expected 'exit 0'; got 'exit %d'", code)
-	}
+	status := ExecDriver(mockFlexvolumeDriver{}, []string{"oci", "attach", defaultTestOps, "nodeName"})
+	expected := DriverStatus{Status: "Not supported"}
+	assertFailure(t, expected, status)
 }

--- a/pkg/oci/driver/block/block_driver.go
+++ b/pkg/oci/driver/block/block_driver.go
@@ -1,0 +1,247 @@
+// Copyright 2017 Oracle and/or its affiliates. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package block
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/oracle/oci-flexvolume-driver/pkg/flexvolume"
+	"github.com/oracle/oci-flexvolume-driver/pkg/iscsi"
+	"github.com/oracle/oci-flexvolume-driver/pkg/oci/client"
+	"github.com/oracle/oci-flexvolume-driver/pkg/oci/driver"
+
+	"github.com/oracle/oci-go-sdk/core"
+)
+
+const (
+	// FIXME: Assume lun 1 for now?? Can we get the LUN via the API?
+	diskIDByPathTemplate = "/dev/disk/by-path/ip-%s:%d-iscsi-%s-lun-1"
+)
+
+// Driver implements the flexvolume.Driver interface for OCI.
+type Driver struct{}
+
+func init() {
+	driver.Register("oci-bvs", &Driver{})
+}
+
+// Init checks that we have the appropriate credentials and metadata API access
+// on driver initialisation.
+func (d Driver) Init() flexvolume.DriverStatus {
+	configPath := driver.GetConfigPath()
+
+	if _, err := os.Stat(configPath); !os.IsNotExist(err) {
+		_, err = client.New(configPath)
+		if err != nil {
+			return flexvolume.Fail(err)
+		}
+	} else {
+		log.Printf("Config file %q does not exist. Assuming worker node.", configPath)
+	}
+
+	return flexvolume.Succeed()
+}
+
+// Attach initiates the attachment of the given OCI volume to the k8s worker
+// node.
+func (d Driver) Attach(opts flexvolume.Options, nodeName string) flexvolume.DriverStatus {
+	c, err := client.New(driver.GetConfigPath())
+	if err != nil {
+		return flexvolume.Fail(err)
+	}
+
+	instance, err := c.GetInstanceByNodeName(nodeName)
+	if err != nil {
+		return flexvolume.Fail(err)
+	}
+
+	volumeOCID := driver.DeriveVolumeOCID(c.GetConfig().Auth.RegionKey, opts["kubernetes.io/pvOrVolumeName"])
+
+	log.Printf("Attaching volume %s -> instance %s", volumeOCID, *instance.Id)
+
+	attachment, statusCode, err := c.AttachVolume(*instance.Id, volumeOCID)
+	if err != nil {
+		if statusCode != 409 {
+			log.Printf("AttachVolume: %+v", err)
+			return flexvolume.Fail(err)
+		}
+		// If we get a 409 conflict response when attaching we
+		// presume that the device is already attached.
+		log.Printf("Attach(): Volume %q already attached.", volumeOCID)
+		attachment, err = c.FindVolumeAttachment(volumeOCID)
+		if err != nil {
+			return flexvolume.Fail(err)
+		}
+		if *attachment.GetInstanceId() != *instance.Id {
+			return flexvolume.Fail("Already attached to instance: ", *instance.Id)
+		}
+	}
+
+	attachment, err = c.WaitForVolumeAttached(*attachment.GetId())
+	if err != nil {
+		return flexvolume.Fail(err)
+	}
+
+	log.Printf("attach: %s attached", *attachment.GetId())
+	iscsiAttachment, ok := attachment.(core.IScsiVolumeAttachment)
+	if !ok {
+		return flexvolume.Fail("Only ISCSI volume attachments are currently supported")
+	}
+
+	return flexvolume.DriverStatus{
+		Status: flexvolume.StatusSuccess,
+		Device: fmt.Sprintf(diskIDByPathTemplate, *iscsiAttachment.Ipv4, *iscsiAttachment.Port, *iscsiAttachment.Iqn),
+	}
+}
+
+// Detach detaches the volume from the worker node.
+func (d Driver) Detach(pvOrVolumeName, nodeName string) flexvolume.DriverStatus {
+	c, err := client.New(driver.GetConfigPath())
+	if err != nil {
+		return flexvolume.Fail(err)
+	}
+
+	volumeOCID := driver.DeriveVolumeOCID(c.GetConfig().Auth.RegionKey, pvOrVolumeName)
+	attachment, err := c.FindVolumeAttachment(volumeOCID)
+	if err != nil {
+		return flexvolume.Fail(err)
+	}
+
+	err = c.DetachVolume(*attachment.GetId())
+	if err != nil {
+		return flexvolume.Fail(err)
+	}
+
+	err = c.WaitForVolumeDetached(*attachment.GetId())
+	if err != nil {
+		return flexvolume.Fail(err)
+	}
+	return flexvolume.Succeed()
+}
+
+// WaitForAttach searches for the the volume attachment created by Attach() and
+// waits for its life cycle state to reach ATTACHED.
+func (d Driver) WaitForAttach(mountDevice string, _ flexvolume.Options) flexvolume.DriverStatus {
+	return flexvolume.DriverStatus{
+		Status: flexvolume.StatusSuccess,
+		Device: mountDevice,
+	}
+}
+
+// IsAttached checks whether the volume is attached to the host.
+// TODO(apryde): The documentation states that this is called from the Kubelet
+// and KCM. Implementation requries credentials which won't be present on nodes
+// but I've only ever seen it called by the KCM.
+func (d Driver) IsAttached(opts flexvolume.Options, nodeName string) flexvolume.DriverStatus {
+	c, err := client.New(driver.GetConfigPath())
+	if err != nil {
+		return flexvolume.Fail(err)
+	}
+
+	volumeOCID := driver.DeriveVolumeOCID(c.GetConfig().Auth.RegionKey, opts["kubernetes.io/pvOrVolumeName"])
+	attachment, err := c.FindVolumeAttachment(volumeOCID)
+	if err != nil {
+		return flexvolume.DriverStatus{
+			Status:   flexvolume.StatusSuccess,
+			Message:  err.Error(),
+			Attached: false,
+		}
+	}
+
+	log.Printf("attach: found volume attachment %s", *attachment.GetId())
+
+	return flexvolume.DriverStatus{
+		Status:   flexvolume.StatusSuccess,
+		Attached: true,
+	}
+}
+
+// MountDevice connects the iSCSI target on the k8s worker node before mounting
+// and (if necessary) formatting the disk.
+func (d Driver) MountDevice(mountDir, mountDevice string, opts flexvolume.Options) flexvolume.DriverStatus {
+	iSCSIMounter, err := iscsi.NewFromDevicePath(mountDevice)
+	if err != nil {
+		return flexvolume.Fail(err)
+	}
+
+	if isMounted, oErr := iSCSIMounter.DeviceOpened(mountDevice); oErr != nil {
+		return flexvolume.Fail(oErr)
+	} else if isMounted {
+		return flexvolume.Succeed("Device already mounted. Nothing to do.")
+	}
+
+	if err = iSCSIMounter.AddToDB(); err != nil {
+		return flexvolume.Fail(err)
+	}
+	if err = iSCSIMounter.SetAutomaticLogin(); err != nil {
+		return flexvolume.Fail(err)
+	}
+	if err = iSCSIMounter.Login(); err != nil {
+		return flexvolume.Fail(err)
+	}
+
+	if !waitForPathToExist(mountDevice, 20) {
+		return flexvolume.Fail("Failed waiting for device to exist: ", mountDevice)
+	}
+
+	options := []string{}
+	if opts[flexvolume.OptionReadWrite] == "ro" {
+		options = []string{"ro"}
+	}
+	err = iSCSIMounter.FormatAndMount(mountDevice, mountDir, opts[flexvolume.OptionFSType], options)
+	if err != nil {
+		return flexvolume.Fail(err)
+	}
+
+	return flexvolume.Succeed()
+}
+
+// UnmountDevice unmounts the disk, logs out the iscsi target, and deletes the
+// iscsi node record.
+func (d Driver) UnmountDevice(mountPath string) flexvolume.DriverStatus {
+	iSCSIMounter, err := iscsi.NewFromMountPointPath(mountPath)
+	if err != nil {
+		if err == iscsi.ErrMountPointNotFound {
+			return flexvolume.Succeed("Mount point not found. Nothing to do.")
+		}
+		return flexvolume.Fail(err)
+	}
+
+	if err = iSCSIMounter.UnmountPath(mountPath); err != nil {
+		return flexvolume.Fail(err)
+	}
+	if err = iSCSIMounter.Logout(); err != nil {
+		return flexvolume.Fail(err)
+	}
+	if err = iSCSIMounter.RemoveFromDB(); err != nil {
+		return flexvolume.Fail(err)
+	}
+
+	return flexvolume.Succeed()
+}
+
+// Mount is unimplemented as we use the --enable-controller-attach-detach flow
+// and as such mount the drive in MountDevice().
+func (d Driver) Mount(mountDir string, opts flexvolume.Options) flexvolume.DriverStatus {
+	return flexvolume.NotSupported()
+}
+
+// Unmount is unimplemented as we use the --enable-controller-attach-detach flow
+// and as such unmount the drive in UnmountDevice().
+func (d Driver) Unmount(mountDir string) flexvolume.DriverStatus {
+	return flexvolume.NotSupported()
+}

--- a/pkg/oci/driver/block/utils.go
+++ b/pkg/oci/driver/block/utils.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package driver
+package block
 
 import (
 	"os"

--- a/pkg/oci/driver/driver.go
+++ b/pkg/oci/driver/driver.go
@@ -16,50 +16,36 @@ package driver
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
 
 	"github.com/oracle/oci-flexvolume-driver/pkg/flexvolume"
-	"github.com/oracle/oci-flexvolume-driver/pkg/iscsi"
-	"github.com/oracle/oci-flexvolume-driver/pkg/oci/client"
-
-	"github.com/oracle/oci-go-sdk/core"
-)
-
-const (
-	// FIXME: Assume lun 1 for now?? Can we get the LUN via the API?
-	diskIDByPathTemplate = "/dev/disk/by-path/ip-%s:%d-iscsi-%s-lun-1"
-	volumeOCIDTemplate   = "ocid1.volume.oc1.%s.%s"
-	ocidPrefix           = "ocid1."
 )
 
 // DefaultDriver is the default flexvolume driver symlink extension.
 const DefaultDriver string = "oci-bvs"
 
+const (
+	volumeOCIDTemplate = "ocid1.volume.oc1.%s.%s"
+	ocidPrefix         = "ocid1."
+)
+
 var (
 	drivers = make(map[string]flexvolume.Driver)
 )
 
-// OCIFlexvolumeDriver implements the flexvolume.Driver interface for OCI.
-type OCIFlexvolumeDriver struct{}
-
-func init() {
-	registerDriver("oci-bvs", &OCIFlexvolumeDriver{})
-}
-
-// RegisterDriver adds a driver to the drivers map.
-func registerDriver(name string, driver flexvolume.Driver) {
+// Register adds a driver to the drivers map.
+func Register(name string, driver flexvolume.Driver) {
 	driver, ok := drivers[name]
 	if !ok {
 		drivers[name] = driver
 	}
 }
 
-// GetDriver returns a driver from the map associated with a given key.
-func GetDriver(name string) (flexvolume.Driver, error) {
+// Get returns a driver from the map associated with a given key.
+func Get(name string) (flexvolume.Driver, error) {
 	driver, ok := drivers[name]
 	if !ok {
 		return nil, fmt.Errorf("could not find a registered driver for %s", name)
@@ -67,8 +53,8 @@ func GetDriver(name string) (flexvolume.Driver, error) {
 	return driver, nil
 }
 
-// GetDriverName returns the name (map key) of the driver from a given path.
-func GetDriverName(args []string) string {
+// NameFromArgs returns the name (map key) of the driver from a given path.
+func NameFromArgs(args []string) string {
 	if len(args) == 0 {
 		return DefaultDriver
 	}
@@ -80,9 +66,9 @@ func GetDriverName(args []string) string {
 	return driverName
 }
 
-// GetDriverDirectory gets the ath for the flexvolume driver either from the
+// GetDirectory gets the ath for the flexvolume driver either from the
 // env or default.
-func GetDriverDirectory() string {
+func GetDirectory() string {
 	// TODO(apryde): Document this ENV var.
 	path := os.Getenv("OCI_FLEXD_DRIVER_DIRECTORY")
 	if path == "" {
@@ -98,31 +84,14 @@ func GetConfigPath() string {
 		return filepath.Join(path, "config.yaml")
 	}
 
-	return filepath.Join(GetDriverDirectory(), "config.yaml")
-}
-
-// Init checks that we have the appropriate credentials and metadata API access
-// on driver initialisation.
-func (d OCIFlexvolumeDriver) Init() flexvolume.DriverStatus {
-	configPath := GetConfigPath()
-
-	if _, err := os.Stat(configPath); !os.IsNotExist(err) {
-		_, err = client.New(configPath)
-		if err != nil {
-			return flexvolume.Fail(err)
-		}
-	} else {
-		log.Printf("Config file %q does not exist. Assuming worker node.", configPath)
-	}
-
-	return flexvolume.Succeed()
+	return filepath.Join(GetDirectory(), "config.yaml")
 }
 
 // deriveVolumeOCID will figure out the correct OCID for a volume
 // based solely on the region key and volumeName. Because of differences
 // across regions we need to impose some awkward logic here to get the correct
 // OCID or if it is already an OCID then return the OCID.
-func deriveVolumeOCID(regionKey string, volumeName string) string {
+func DeriveVolumeOCID(regionKey string, volumeName string) string {
 	if strings.HasPrefix(volumeName, ocidPrefix) {
 		return volumeName
 	}
@@ -135,194 +104,4 @@ func deriveVolumeOCID(regionKey string, volumeName string) string {
 	}
 
 	return volumeOCID
-}
-
-// Attach initiates the attachment of the given OCI volume to the k8s worker
-// node.
-func (d OCIFlexvolumeDriver) Attach(opts flexvolume.Options, nodeName string) flexvolume.DriverStatus {
-	c, err := client.New(GetConfigPath())
-	if err != nil {
-		return flexvolume.Fail(err)
-	}
-
-	instance, err := c.GetInstanceByNodeName(nodeName)
-	if err != nil {
-		return flexvolume.Fail(err)
-	}
-
-	volumeOCID := deriveVolumeOCID(c.GetConfig().Auth.RegionKey, opts["kubernetes.io/pvOrVolumeName"])
-
-	log.Printf("Attaching volume %s -> instance %s", volumeOCID, *instance.Id)
-
-	attachment, statusCode, err := c.AttachVolume(*instance.Id, volumeOCID)
-	if err != nil {
-		if statusCode != 409 {
-			log.Printf("AttachVolume: %+v", err)
-			return flexvolume.Fail(err)
-		}
-		// If we get a 409 conflict response when attaching we
-		// presume that the device is already attached.
-		log.Printf("Attach(): Volume %q already attached.", volumeOCID)
-		attachment, err = c.FindVolumeAttachment(volumeOCID)
-		if err != nil {
-			return flexvolume.Fail(err)
-		}
-		if *attachment.GetInstanceId() != *instance.Id {
-			return flexvolume.Fail("Already attached to instance: ", *instance.Id)
-		}
-	}
-
-	attachment, err = c.WaitForVolumeAttached(*attachment.GetId())
-	if err != nil {
-		return flexvolume.Fail(err)
-	}
-
-	log.Printf("attach: %s attached", *attachment.GetId())
-	iscsiAttachment, ok := attachment.(core.IScsiVolumeAttachment)
-	if !ok {
-		return flexvolume.Fail("Only ISCSI volume attachments are currently supported")
-	}
-
-	return flexvolume.DriverStatus{
-		Status: flexvolume.StatusSuccess,
-		Device: fmt.Sprintf(diskIDByPathTemplate, *iscsiAttachment.Ipv4, *iscsiAttachment.Port, *iscsiAttachment.Iqn),
-	}
-}
-
-// Detach detaches the volume from the worker node.
-func (d OCIFlexvolumeDriver) Detach(pvOrVolumeName, nodeName string) flexvolume.DriverStatus {
-	c, err := client.New(GetConfigPath())
-	if err != nil {
-		return flexvolume.Fail(err)
-	}
-
-	volumeOCID := deriveVolumeOCID(c.GetConfig().Auth.RegionKey, pvOrVolumeName)
-	attachment, err := c.FindVolumeAttachment(volumeOCID)
-	if err != nil {
-		return flexvolume.Fail(err)
-	}
-
-	err = c.DetachVolume(*attachment.GetId())
-	if err != nil {
-		return flexvolume.Fail(err)
-	}
-
-	err = c.WaitForVolumeDetached(*attachment.GetId())
-	if err != nil {
-		return flexvolume.Fail(err)
-	}
-	return flexvolume.Succeed()
-}
-
-// WaitForAttach searches for the the volume attachment created by Attach() and
-// waits for its life cycle state to reach ATTACHED.
-func (d OCIFlexvolumeDriver) WaitForAttach(mountDevice string, _ flexvolume.Options) flexvolume.DriverStatus {
-	return flexvolume.DriverStatus{
-		Status: flexvolume.StatusSuccess,
-		Device: mountDevice,
-	}
-}
-
-// IsAttached checks whether the volume is attached to the host.
-// TODO(apryde): The documentation states that this is called from the Kubelet
-// and KCM. Implementation requries credentials which won't be present on nodes
-// but I've only ever seen it called by the KCM.
-func (d OCIFlexvolumeDriver) IsAttached(opts flexvolume.Options, nodeName string) flexvolume.DriverStatus {
-	c, err := client.New(GetConfigPath())
-	if err != nil {
-		return flexvolume.Fail(err)
-	}
-
-	volumeOCID := deriveVolumeOCID(c.GetConfig().Auth.RegionKey, opts["kubernetes.io/pvOrVolumeName"])
-	attachment, err := c.FindVolumeAttachment(volumeOCID)
-	if err != nil {
-		return flexvolume.DriverStatus{
-			Status:   flexvolume.StatusSuccess,
-			Message:  err.Error(),
-			Attached: false,
-		}
-	}
-
-	log.Printf("attach: found volume attachment %s", *attachment.GetId())
-
-	return flexvolume.DriverStatus{
-		Status:   flexvolume.StatusSuccess,
-		Attached: true,
-	}
-}
-
-// MountDevice connects the iSCSI target on the k8s worker node before mounting
-// and (if necessary) formatting the disk.
-func (d OCIFlexvolumeDriver) MountDevice(mountDir, mountDevice string, opts flexvolume.Options) flexvolume.DriverStatus {
-	iSCSIMounter, err := iscsi.NewFromDevicePath(mountDevice)
-	if err != nil {
-		return flexvolume.Fail(err)
-	}
-
-	if isMounted, oErr := iSCSIMounter.DeviceOpened(mountDevice); oErr != nil {
-		return flexvolume.Fail(oErr)
-	} else if isMounted {
-		return flexvolume.Succeed("Device already mounted. Nothing to do.")
-	}
-
-	if err = iSCSIMounter.AddToDB(); err != nil {
-		return flexvolume.Fail(err)
-	}
-	if err = iSCSIMounter.SetAutomaticLogin(); err != nil {
-		return flexvolume.Fail(err)
-	}
-	if err = iSCSIMounter.Login(); err != nil {
-		return flexvolume.Fail(err)
-	}
-
-	if !waitForPathToExist(mountDevice, 20) {
-		return flexvolume.Fail("Failed waiting for device to exist: ", mountDevice)
-	}
-
-	options := []string{}
-	if opts[flexvolume.OptionReadWrite] == "ro" {
-		options = []string{"ro"}
-	}
-	err = iSCSIMounter.FormatAndMount(mountDevice, mountDir, opts[flexvolume.OptionFSType], options)
-	if err != nil {
-		return flexvolume.Fail(err)
-	}
-
-	return flexvolume.Succeed()
-}
-
-// UnmountDevice unmounts the disk, logs out the iscsi target, and deletes the
-// iscsi node record.
-func (d OCIFlexvolumeDriver) UnmountDevice(mountPath string) flexvolume.DriverStatus {
-	iSCSIMounter, err := iscsi.NewFromMountPointPath(mountPath)
-	if err != nil {
-		if err == iscsi.ErrMountPointNotFound {
-			return flexvolume.Succeed("Mount point not found. Nothing to do.")
-		}
-		return flexvolume.Fail(err)
-	}
-
-	if err = iSCSIMounter.UnmountPath(mountPath); err != nil {
-		return flexvolume.Fail(err)
-	}
-	if err = iSCSIMounter.Logout(); err != nil {
-		return flexvolume.Fail(err)
-	}
-	if err = iSCSIMounter.RemoveFromDB(); err != nil {
-		return flexvolume.Fail(err)
-	}
-
-	return flexvolume.Succeed()
-}
-
-// Mount is unimplemented as we use the --enable-controller-attach-detach flow
-// and as such mount the drive in MountDevice().
-func (d OCIFlexvolumeDriver) Mount(mountDir string, opts flexvolume.Options) flexvolume.DriverStatus {
-	return flexvolume.NotSupported()
-}
-
-// Unmount is unimplemented as we use the --enable-controller-attach-detach flow
-// and as such unmount the drive in UnmountDevice().
-func (d OCIFlexvolumeDriver) Unmount(mountDir string) flexvolume.DriverStatus {
-	return flexvolume.NotSupported()
 }

--- a/pkg/oci/driver/driver_test.go
+++ b/pkg/oci/driver/driver_test.go
@@ -31,7 +31,7 @@ var volumeOCIDTests = []struct {
 
 func TestDeriveVolumeOCID(t *testing.T) {
 	for _, tt := range volumeOCIDTests {
-		result := deriveVolumeOCID(tt.regionKey, tt.volumeName)
+		result := DeriveVolumeOCID(tt.regionKey, tt.volumeName)
 		if result != tt.expected {
 			t.Errorf("Failed to derive OCID. Expected %s got %s", tt.expected, result)
 		}

--- a/test/integration/attach_nonexistent_volume_test.go
+++ b/test/integration/attach_nonexistent_volume_test.go
@@ -18,12 +18,12 @@ import (
 	"testing"
 
 	"github.com/oracle/oci-flexvolume-driver/pkg/flexvolume"
-	"github.com/oracle/oci-flexvolume-driver/pkg/oci/driver"
+	"github.com/oracle/oci-flexvolume-driver/pkg/oci/driver/block"
 )
 
 // TestAttachNonexistentVolume tests that attach fails for invalid volume OCIDs.
 func TestAttachNonexistentVolume(t *testing.T) {
-	d := &driver.OCIFlexvolumeDriver{}
+	d := &block.Driver{}
 	opts := flexvolume.Options{
 		"kubernetes.io/fsType":         "ext4",
 		"kubernetes.io/pvOrVolumeName": "non-existent-volume",

--- a/test/integration/basic_test.go
+++ b/test/integration/basic_test.go
@@ -19,12 +19,12 @@ import (
 	"testing"
 
 	"github.com/oracle/oci-flexvolume-driver/pkg/flexvolume"
-	"github.com/oracle/oci-flexvolume-driver/pkg/oci/driver"
+	"github.com/oracle/oci-flexvolume-driver/pkg/oci/driver/block"
 )
 
 // TestBasic tests the basic attach, mount, unmount, detach flow.
 func TestBasic(t *testing.T) {
-	d := &driver.OCIFlexvolumeDriver{}
+	d := &block.Driver{}
 	opts := flexvolume.Options{
 		"kubernetes.io/fsType":         "ext4",
 		"kubernetes.io/pvOrVolumeName": fw.VolumeName,

--- a/test/integration/idempotent_test.go
+++ b/test/integration/idempotent_test.go
@@ -19,13 +19,13 @@ import (
 	"testing"
 
 	"github.com/oracle/oci-flexvolume-driver/pkg/flexvolume"
-	"github.com/oracle/oci-flexvolume-driver/pkg/oci/driver"
+	"github.com/oracle/oci-flexvolume-driver/pkg/oci/driver/block"
 )
 
 // TestIdempotent checks that Attach, MountDevice, and UnmountDevice are
 // idempotent and (currently) that Detach is **not** idempotent.
 func TestIdempotent(t *testing.T) {
-	d := &driver.OCIFlexvolumeDriver{}
+	d := &block.Driver{}
 	opts := flexvolume.Options{
 		"kubernetes.io/fsType":         "ext4",
 		"kubernetes.io/pvOrVolumeName": fw.VolumeName,

--- a/test/integration/mount_inconsistent_test.go
+++ b/test/integration/mount_inconsistent_test.go
@@ -19,13 +19,13 @@ import (
 	"testing"
 
 	"github.com/oracle/oci-flexvolume-driver/pkg/flexvolume"
-	"github.com/oracle/oci-flexvolume-driver/pkg/oci/driver"
+	"github.com/oracle/oci-flexvolume-driver/pkg/oci/driver/block"
 )
 
 // TestMountInconsistentFileSystems checks an error is returned if the attached
 // disk has an existing filesytem that differs from specified filesystem.
 func TestMountInconsistentFileSystems(t *testing.T) {
-	d := &driver.OCIFlexvolumeDriver{}
+	d := &block.Driver{}
 	opts := flexvolume.Options{
 		"kubernetes.io/fsType":         "ext4",
 		"kubernetes.io/pvOrVolumeName": fw.VolumeName,

--- a/test/integration/mount_nonexistent_path_test.go
+++ b/test/integration/mount_nonexistent_path_test.go
@@ -18,13 +18,13 @@ import (
 	"testing"
 
 	"github.com/oracle/oci-flexvolume-driver/pkg/flexvolume"
-	"github.com/oracle/oci-flexvolume-driver/pkg/oci/driver"
+	"github.com/oracle/oci-flexvolume-driver/pkg/oci/driver/block"
 )
 
 // TestMountNonexistentPath checks an error is return when the required mout
 // point does not exist during mounting.
 func TestMountNonexistentPath(t *testing.T) {
-	d := &driver.OCIFlexvolumeDriver{}
+	d := &block.Driver{}
 	opts := flexvolume.Options{
 		"kubernetes.io/fsType":         "ext4",
 		"kubernetes.io/pvOrVolumeName": fw.VolumeName,


### PR DESCRIPTION
Addresses oracle/oci-volume-provisioner#131

The volume provisioner has been patched to now not use names to dispatch custom logic. A storage class can now use it's provisioner property to determine what driver should be used. At the moment only block volume storage is supported provisioner: ```oracle.com/oci-bvs``` with aim that file storage will soon be supported also oracle/oci-volume-provisioner#90. Backwards compatible so that existing storage classes using provisioner: ```oracle.com/oci``` will default to using the block volume storage however this should be marked as deprecated and removed in a future release.