### PR TITLE
WIP: Use tenancy not username in image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ build:
 manifests: build
 	@cp -a manifests/* dist
 	@sed ${SED_INPLACE} 's#__VERSION__#${VERSION}#g' dist/oci-flexvolume-driver.yaml
-	@sed ${SED_INPLACE} 's#__DOCKER_REGISTRY_USERNAME__#${DOCKER_REGISTRY_USERNAME}#g' dist/oci-flexvolume-driver.yaml
+	@sed ${SED_INPLACE} 's#__DOCKER_REGISTRY_TENANCY__#${DOCKER_REGISTRY_TENANCY}#g' dist/oci-flexvolume-driver.yaml
 
 .PHONY: build-integration-tests
 build-integration-tests:

--- a/manifests/oci-flexvolume-driver.yaml
+++ b/manifests/oci-flexvolume-driver.yaml
@@ -11,7 +11,7 @@ spec:
         app: oci-flexvolume-driver
     spec:
       nodeSelector:
-        node-role.kubernetes.io/master: "true"
+        node-role.kubernetes.io/master: ""
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         value: "true"
@@ -20,7 +20,7 @@ spec:
         operator: Exists
         effect: NoSchedule
       containers:
-        - image: iad.ocir.io/__DOCKER_REGISTRY_USERNAME__/oci-flexvolume-driver:__VERSION__
+        - image: iad.ocir.io/__DOCKER_REGISTRY_TENANCY__/oci-flexvolume-driver:__VERSION__
           imagePullPolicy: Always
           name: oci-flexvolume-driver
           securityContext:
@@ -53,7 +53,7 @@ spec:
         app: oci-flexvolume-driver
     spec:
       containers:
-        - image: iad.ocir.io/__DOCKER_REGISTRY_USERNAME__/oci-flexvolume-driver:__VERSION__
+        - image: iad.ocir.io/__DOCKER_REGISTRY_TENANCY__/oci-flexvolume-driver:__VERSION__
           imagePullPolicy: Always
           name: oci-flexvolume-driver
           securityContext:

--- a/pkg/oci/client/config.go
+++ b/pkg/oci/client/config.go
@@ -78,8 +78,10 @@ func NewConfig(r io.Reader) (*Config, error) {
 
 	c.metadata = instancemeta.New()
 
-	if err := c.setDefaults(); err != nil {
-		return nil, err
+	if !c.UseInstancePrincipals {
+		if err := c.setDefaults(); err != nil {
+			return nil, err
+		}
 	}
 
 	if err := c.validate(); err != nil {
@@ -167,6 +169,9 @@ func validateAuthConfig(c *Config, fldPath *field.Path) field.ErrorList {
 	if c.UseInstancePrincipals {
 		if c.Auth.Region != "" {
 			errList = append(errList, field.Forbidden(fldPath.Child("region"), "cannot be used when useInstancePrincipals is enabled"))
+		}
+		if c.Auth.CompartmentOCID != "" {
+			errList = append(errList, field.Forbidden(fldPath.Child("compartment"), "cannot be used when useInstancePrincipals is enabled"))
 		}
 		if c.Auth.TenancyOCID != "" {
 			errList = append(errList, field.Forbidden(fldPath.Child("tenancy"), "cannot be used when useInstancePrincipals is enabled"))


### PR DESCRIPTION
Currently the manifest yaml is set up to use 'DOCKER_REGISTRY_USERNAME' in the image name. This is wrong and should be 'DOCKER_REGISTRY_TENANCY'.