### PR TITLE
Use tenancy over username in image path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ build:
 manifests: build
 	@cp -a manifests/* dist
 	@sed ${SED_INPLACE} 's#__VERSION__#${VERSION}#g' dist/oci-flexvolume-driver.yaml
-	@sed ${SED_INPLACE} 's#__DOCKER_REGISTRY_USERNAME__#${DOCKER_REGISTRY_USERNAME}#g' dist/oci-flexvolume-driver.yaml
+	@sed ${SED_INPLACE} 's#__DOCKER_REGISTRY_TENANCY__#${DOCKER_REGISTRY_TENANCY}#g' dist/oci-flexvolume-driver.yaml
 
 .PHONY: build-integration-tests
 build-integration-tests:

--- a/manifests/oci-flexvolume-driver.yaml
+++ b/manifests/oci-flexvolume-driver.yaml
@@ -20,7 +20,7 @@ spec:
         operator: Exists
         effect: NoSchedule
       containers:
-        - image: iad.ocir.io/__DOCKER_REGISTRY_USERNAME__/oci-flexvolume-driver:__VERSION__
+        - image: iad.ocir.io/__DOCKER_REGISTRY_TENANCY__/oci-flexvolume-driver:__VERSION__
           imagePullPolicy: Always
           name: oci-flexvolume-driver
           securityContext:
@@ -53,7 +53,7 @@ spec:
         app: oci-flexvolume-driver
     spec:
       containers:
-        - image: iad.ocir.io/__DOCKER_REGISTRY_USERNAME__/oci-flexvolume-driver:__VERSION__
+        - image: iad.ocir.io/__DOCKER_REGISTRY_TENANCY__/oci-flexvolume-driver:__VERSION__
           imagePullPolicy: Always
           name: oci-flexvolume-driver
           securityContext:


### PR DESCRIPTION
Replaces `DOCKER_REGISTRY_USERNAME` with `DOCKER_REGISTRY_TENANCY` in the DaemonSet yaml image path.