### PR TITLE
Fix master DaemonSet deployment

### DIFF
--- a/manifests/oci-flexvolume-driver.yaml
+++ b/manifests/oci-flexvolume-driver.yaml
@@ -11,7 +11,7 @@ spec:
         app: oci-flexvolume-driver
     spec:
       nodeSelector:
-        node-role.kubernetes.io/master: "true"
+        node-role.kubernetes.io/master: ""
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         value: "true"


### PR DESCRIPTION
Currently the master daemonset is not being deployed due to `node-role.kubernetes.io/master` being set to true. This is fixed by assigning an empty value.