### PR TITLE
Lookup subnets in VCN compartment

### DIFF
--- a/pkg/oci/client/config.go
+++ b/pkg/oci/client/config.go
@@ -42,11 +42,11 @@ type AuthConfig struct {
 	Region               string `yaml:"region"`
 	RegionKey            string `yaml:"regionKey"`
 	TenancyOCID          string `yaml:"tenancy"`
-	CompartmentOCID      string `yaml:"compartment"`
+	CompartmentOCID      string `yaml:"compartment"` // DEPRECATED (we no longer directly use this)
 	UserOCID             string `yaml:"user"`
 	PrivateKey           string `yaml:"key"`
 	Passphrase           string `yaml:"passphrase"`
-	PrivateKeyPassphrase string `yaml:"key_passphase"` // DEPRECIATED
+	PrivateKeyPassphrase string `yaml:"key_passphase"` // DEPRECATED
 	Fingerprint          string `yaml:"fingerprint"`
 	VcnOCID              string `yaml:"vcn"`
 }
@@ -186,9 +186,6 @@ func validateAuthConfig(c *Config, fldPath *field.Path) field.ErrorList {
 		}
 		if c.Auth.TenancyOCID == "" {
 			errList = append(errList, field.Required(fldPath.Child("tenancy"), ""))
-		}
-		if c.Auth.CompartmentOCID == "" {
-			errList = append(errList, field.Required(fldPath.Child("compartment"), ""))
 		}
 		if c.Auth.UserOCID == "" {
 			errList = append(errList, field.Required(fldPath.Child("user"), ""))

--- a/pkg/oci/client/config_test.go
+++ b/pkg/oci/client/config_test.go
@@ -169,22 +169,6 @@ func TestValidateConfig(t *testing.T) {
 				&field.Error{Type: field.ErrorTypeRequired, Field: "auth.tenancy", BadValue: ""},
 			},
 		}, {
-			name: "missing_compartment_ocid",
-			in: &Config{
-				Auth: AuthConfig{
-					Region:      "us-phoenix-1",
-					RegionKey:   "phx",
-					TenancyOCID: "ocid1.tennancy.oc1..aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-					UserOCID:    "ocid1.user.oc1..aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-					PrivateKey:  "-----BEGIN RSA PRIVATE KEY----- (etc)",
-					Fingerprint: "d4:1d:8c:d9:8f:00:b2:04:e9:80:09:98:ec:f8:42:7e",
-					VcnOCID:     "ocid1.user.oc1..aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-				},
-			},
-			errs: field.ErrorList{
-				&field.Error{Type: field.ErrorTypeRequired, Field: "auth.compartment", BadValue: ""},
-			},
-		}, {
 			name: "missing_user_ocid",
 			in: &Config{
 				Auth: AuthConfig{
@@ -217,7 +201,7 @@ func TestValidateConfig(t *testing.T) {
 				&field.Error{Type: field.ErrorTypeRequired, Field: "auth.key", BadValue: ""},
 			},
 		}, {
-			name: "missing_figerprint",
+			name: "missing_fingerprint",
 			in: &Config{
 				Auth: AuthConfig{
 					Region:          "us-phoenix-1",

--- a/pkg/oci/client/oci.go
+++ b/pkg/oci/client/oci.go
@@ -163,9 +163,15 @@ func (c *client) WaitForVolumeAttached(volumeAttachmentId string) (core.VolumeAt
 // ATTACHING or ATTACHED and returns the first volume attachment found.
 func (c *client) FindVolumeAttachment(volumeId string) (core.VolumeAttachment, error) {
 	var page *string
+
+	vcnCompartment, err := c.getVCNCompartment()
+	if err != nil {
+		return nil, err
+	}
+
 	for {
 		request := core.ListVolumeAttachmentsRequest{
-			CompartmentId: &c.config.Auth.CompartmentOCID,
+			CompartmentId: vcnCompartment,
 			Page:          page,
 			VolumeId:      &volumeId,
 		}
@@ -195,12 +201,25 @@ func (c *client) FindVolumeAttachment(volumeId string) (core.VolumeAttachment, e
 	return nil, fmt.Errorf("failed to find volume attachment for %q", volumeId)
 }
 
-func (c *client) getAllSubnetsForVNC() (*[]core.Subnet, error) {
+func (c *client) getVCNCompartment() (*string, error) {
+	ctx, cancel := context.WithTimeout(c.ctx, time.Minute)
+	defer cancel()
+
+	vcn, err := c.network.GetVcn(ctx, core.GetVcnRequest{VcnId: &c.config.Auth.VcnOCID})
+	if err != nil {
+		return nil, err
+	}
+
+	return vcn.CompartmentId, nil
+}
+
+func (c *client) getAllSubnetsForVCN(vcnCompartment *string) (*[]core.Subnet, error) {
 	var page *string
 	subnetList := []core.Subnet{}
+
 	for {
 		request := core.ListSubnetsRequest{
-			CompartmentId: &c.config.Auth.CompartmentOCID,
+			CompartmentId: vcnCompartment,
 			VcnId:         &c.config.Auth.VcnOCID,
 			Page:          page,
 		}
@@ -231,16 +250,16 @@ func (c *client) isVnicAttachmentInSubnets(vnicAttachment *core.VnicAttachment, 
 	return false
 }
 
-// findInstanceByNodeNameIsVnic try to find the BM Instance
-// // it makes the assumption that he nodename has to be resolvable
+// findInstanceByNodeNameIsVNIC tries to find an OCI Instance to attach a volume to.
+// It makes the assumption that the nodename has to be resolvable.
 // https://kubernetes.io/docs/concepts/architecture/nodes/#management
 // So if the displayname doesn't match the nodename then
 // 1) get the IP of the node name doing a reverse lookup and see if we can find it.
 // I'm leaving the DNS lookup till later as the options below fix the OKE issue
 // 2) see if the nodename is equal to the hostname label
-// 3) see if the nodename is an ip
-func (c *client) findInstanceByNodeNameIsVnic(cache *cache.OCICache, nodeName string) (*core.Instance, error) {
-	subnets, err := c.getAllSubnetsForVNC()
+// 3) see if the nodename is an IP
+func (c *client) findInstanceByNodeNameIsVNIC(cache *cache.OCICache, nodeName string, compartment *string) (*core.Instance, error) {
+	subnets, err := c.getAllSubnetsForVCN(compartment)
 	if err != nil {
 		log.Printf("Error getting subnets for VCN: %s", c.config.Auth.VcnOCID)
 		return nil, err
@@ -253,7 +272,7 @@ func (c *client) findInstanceByNodeNameIsVnic(cache *cache.OCICache, nodeName st
 	var page *string
 	for {
 		vnicAttachmentsRequest := core.ListVnicAttachmentsRequest{
-			CompartmentId: &c.config.Auth.CompartmentOCID,
+			CompartmentId: compartment,
 			Page:          page,
 		}
 		vnicAttachments, err := func() (core.ListVnicAttachmentsResponse, error) {
@@ -318,12 +337,14 @@ func (c *client) findInstanceByNodeNameIsVnic(cache *cache.OCICache, nodeName st
 	return &running[0], nil
 }
 
-func (c *client) findInstanceByNodeNameIsDisplayName(nodeName string) (*core.Instance, error) {
+// findInstanceByNodeNameIsDisplayName returns the first running instance where the display name and node name match.
+// If no instance is found we return an error.
+func (c *client) findInstanceByNodeNameIsDisplayName(nodeName string, compartment *string) (*core.Instance, error) {
 	var running []core.Instance
 	var page *string
 	for {
 		listInstancesRequest := core.ListInstancesRequest{
-			CompartmentId: &c.config.Auth.CompartmentOCID,
+			CompartmentId: compartment,
 			DisplayName:   &nodeName,
 			Page:          page,
 		}
@@ -373,18 +394,23 @@ func getCacheDirectory() string {
 // GetInstanceByNodeName retrieves the corresponding core.Instance or a
 // SearchError if no instance matching the node name is found.
 func (c *client) GetInstanceByNodeName(nodeName string) (*core.Instance, error) {
-	log.Printf("GetInstanceByNodeName:%s", nodeName)
+	log.Printf("GetInstanceByNodeName: %s", nodeName)
 	ociCache, err := cache.Open(fmt.Sprintf("%s/%s", getCacheDirectory(), "nodenamecache.json"))
 	if err != nil {
 		return nil, err
 	}
 	defer ociCache.Close()
 
+	vcnCompartment, err := c.getVCNCompartment()
+	if err != nil {
+		return nil, err
+	}
+
 	// Cache lookup failed so time to refill the cache
-	instance, err := c.findInstanceByNodeNameIsDisplayName(nodeName)
+	instance, err := c.findInstanceByNodeNameIsDisplayName(nodeName, vcnCompartment)
 	if err != nil {
 		log.Printf("Unable to find OCI instance by displayname trying hostname/public ip")
-		instance, err = c.findInstanceByNodeNameIsVnic(ociCache, nodeName)
+		instance, err = c.findInstanceByNodeNameIsVNIC(ociCache, nodeName, vcnCompartment)
 		if err != nil {
 			log.Printf("Unable to find OCI instance by hostname/displayname")
 		}


### PR DESCRIPTION
Currently we search for subnets within the compartment specified in the driver configuration file. This causes a problem when the VCN is in a separate compartment to the compartment specified in configuration. The compartment specified in configuration is typically that of the cluster.

Some customers have a split compartment model where the network (VCN) and cluster are in separate compartments. The configuration file already contains the VCN OCID as a mandatory field so we can safely assume it is always present.

This change modifies `getAllSubnetsForVCN` such that the API call to `core.ListSubnets` is performed in the same compartment as the VCN. This is backwards compatible (where the VCN compartment is equal to the cluster compartment).