### PR TITLE
Correct usage of principal auth, and take advantage of OCI canonical region names

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,13 @@ applied to the dynamic group of instances that intend to use the flexvolume driv
 "Allow group id ${oci_identity_group.flexvolume_driver_group.id} to manage volume-attachments in compartment id ${var.compartment_ocid}",
 ```
 
-The configuration file requires a simple configuration in the following format:
+The configuration file for authentication with instance principals requires much less configuration:
 
 ```yaml
 ---
 useInstancePrincipals: true
+auth:
+  vcn: ocid1.vcn.oc1.phx.aaaaaaaaqiqmei4yen2fuyqaiqfcejpguqs6tuaf2n2iaxiwf5cfji2s636a
 ```
 
 #### Extra configuration values

--- a/pkg/oci/instancemeta/instance_metadata.go
+++ b/pkg/oci/instancemeta/instance_metadata.go
@@ -30,7 +30,8 @@ const (
 // https://docs.us-phoenix-1.oraclecloud.com/Content/Compute/Tasks/gettingmetadata.htm
 type InstanceMetadata struct {
 	CompartmentOCID string `json:"compartmentId"`
-	Region          string `json:"region"`
+	RegionKey       string `json:"region"`
+	Region          string `json:"canonicalRegionName"`
 }
 
 // Interface defines how consumers access OCI instance metadata.

--- a/pkg/oci/instancemeta/instance_metadata_test.go
+++ b/pkg/oci/instancemeta/instance_metadata_test.go
@@ -32,6 +32,7 @@ const exampleResponse = `{
     "ssh_authorized_keys" : "ssh-rsa some-key-data tlangfor@tlangfor-mac\n"
   },
   "region" : "phx",
+  "canonicalRegionName" : "us-phoenix-1",
   "shape" : "VM.Standard1.1",
   "state" : "Provisioning",
   "timeCreated" : 1496415602152
@@ -50,7 +51,8 @@ func TestGetMetadata(t *testing.T) {
 
 	expected := &InstanceMetadata{
 		CompartmentOCID: "ocid1.compartment.oc1..aaaaaaaa3um2atybwhder4qttfhgon4j3hcxgmsvnyvx4flfjyewkkwfzwnq",
-		Region:          "phx",
+		RegionKey:       "phx",
+		Region:          "us-phoenix-1",
 	}
 	if !reflect.DeepEqual(meta, expected) {
 		t.Errorf("Get() => %+v, want %+v", meta, expected)


### PR DESCRIPTION
- Allows configuration to be more lenient if we can get values from the metadata service
- Takes advantage of OCI exposure of full region canonical region names via metadata service
- Fixes documentation on principal auth usage. VCN is still required