### PR TITLE
Added override mechanism for kubeconfig. This allows the full path to…

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ You can set these in the environment to override the default values.
 `/usr/libexec/kubernetes/kubelet-plugins/volume/exec/oracle~oci`)
 * `OCI_FLEXD_CONFIG_DIRECTORY` - Directory where the driver configuration lives (Default:
 `/usr/libexec/kubernetes/kubelet-plugins/volume/exec/oracle~oci`)
+* `OCI_FLEXD_KUBECONFIG_PATH` - An override to allow the fully qualified path of the kubeconfig resource file to be specified. This take precedence over additional configuration.
 
 ## OCI Policies
 

--- a/pkg/oci/driver/driver.go
+++ b/pkg/oci/driver/driver.go
@@ -96,6 +96,18 @@ func GetConfigPath() string {
 	return filepath.Join(path, "config.yaml")
 }
 
+// GetKubeconfigPath gets the override path of the 'kubeconfig'. This override
+// can be uses to explicitly set the name and location of the kubeconfig file
+// via the OCI_FLEXD_KUBECONFIG environment variable. If this value is not
+// specified then the default GetConfigDirectory mechanism is used.
+func GetKubeconfigPath() string {
+	kcp := os.Getenv("OCI_FLEXD_KUBECONFIG_PATH")
+	if kcp == "" {
+		kcp = fmt.Sprintf("%s/%s", strings.TrimRight(GetConfigDirectory(), "/"), "kubeconfig")
+	}
+	return kcp
+}
+
 // Init checks that we have the appropriate credentials and metadata API access
 // on driver initialisation.
 func (d OCIFlexvolumeDriver) Init() flexvolume.DriverStatus {
@@ -137,9 +149,9 @@ func deriveVolumeOCID(regionKey string, volumeName string) string {
 }
 
 // constructKubeClient uses a kubeconfig layed down by a secret via deploy.sh to return
-// a kube clientset
+// a kube clientset.
 func constructKubeClient() (*kubernetes.Clientset, error) {
-	fp := GetConfigDirectory() + "/kubeconfig"
+	fp := GetKubeconfigPath()
 
 	c, err := clientcmd.BuildConfigFromFlags("", fp)
 	if err != nil {

--- a/pkg/oci/driver/driver.go
+++ b/pkg/oci/driver/driver.go
@@ -98,7 +98,7 @@ func GetConfigPath() string {
 
 // GetKubeconfigPath gets the override path of the 'kubeconfig'. This override
 // can be uses to explicitly set the name and location of the kubeconfig file
-// via the OCI_FLEXD_KUBECONFIG environment variable. If this value is not
+// via the OCI_FLEXD_KUBECONFIG_PATH environment variable. If this value is not
 // specified then the default GetConfigDirectory mechanism is used.
 func GetKubeconfigPath() string {
 	kcp := os.Getenv("OCI_FLEXD_KUBECONFIG_PATH")

--- a/pkg/oci/driver/driver_test.go
+++ b/pkg/oci/driver/driver_test.go
@@ -78,3 +78,49 @@ func TestGetConfigPath(t *testing.T) {
 
 	}
 }
+
+func TestGetKubeconfigPath(t *testing.T) {
+	testCases := map[string]struct {
+		envvar   string
+		value    string
+		expected string
+	}{
+		"default": {
+			envvar:   "",
+			value:    "",
+			expected: "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/oracle~oci/kubeconfig",
+		},
+		"custom config dir": {
+			envvar:   "OCI_FLEXD_CONFIG_DIRECTORY",
+			value:    "/foo/bar",
+			expected: "/foo/bar/kubeconfig",
+		},
+		"custom config dir with trailing path seperator": {
+			envvar:   "OCI_FLEXD_CONFIG_DIRECTORY",
+			value:    "/foo/bar/",
+			expected: "/foo/bar/kubeconfig",
+		},
+		"override kubeconfig path": {
+			envvar:   "OCI_FLEXD_KUBECONFIG_PATH",
+			value:    "/etc/kubevar/kubeconfig",
+			expected: "/etc/kubevar/kubeconfig",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// idk if we need this but figure it can't hurt
+			original := os.Getenv(tc.envvar)
+			defer os.Setenv(tc.envvar, original)
+
+			// set env var value for the test.
+			os.Setenv(tc.envvar, tc.value)
+
+			result := GetKubeconfigPath()
+			if result != tc.expected {
+				t.Errorf("GetKubeconfigPath() = %q ; wanted %q", result, tc.expected)
+			}
+		})
+
+	}
+}


### PR DESCRIPTION
Allows the kubeconfig to be overridden via the 'OCI_FLEXD_KUBECONFIG_PATH' environment variable. Otherwise the default behaviour is unchanged.